### PR TITLE
Remove grpc from list of install packages

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -19,7 +19,7 @@ jobs:
           python-version: 3.8
 
       - name: Install setuptools and other tools
-        run: python3 -m pip install setuptools wheel twine grpc grpcio
+        run: python3 -m pip install setuptools wheel twine grpcio
 
       - name: Build packages
         run: python3 setup.py bdist_wheel


### PR DESCRIPTION
- [X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niflexlogger-automation-python/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Facilitates publication of the NI FlexLogger automation python package to pypi

### Why should this Pull Request be merged?

As is, trying to publish to pypi generates the following error:
"Please install the official package with: pip install grpcio"

grpcio is the top level official package, and it is not correct to directly install grpc

### What testing has been done?

Running the pip install command now completes without error
