### PR TITLE
Add grpcio-tools to the required publishing tools

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -19,7 +19,7 @@ jobs:
           python-version: 3.8
 
       - name: Install setuptools and other tools
-        run: python3 -m pip install setuptools wheel twine grpcio
+        run: python3 -m pip install setuptools wheel twine grpcio grpcio-tools
 
       - name: Build packages
         run: python3 setup.py bdist_wheel


### PR DESCRIPTION
- [X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niflexlogger-automation-python/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Adds grpcio-tools to the list of packages required for pypi publication

### Why should this Pull Request be merged?

Generating python code from the gRPC proto files (the  _generate_protobuf_classes step of setup.py) requires grpcio-tools

### What testing has been done?

Verified the install command works as expected.
