### PR TITLE
build pypi package on windows, not ubuntu

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   build-and-publish:
     if: github.repository == 'ni/niflexlogger-automation-python'
-    runs-on: ubuntu-latest
+    runs-on: windows-latest
 
     steps:
       - uses: actions/checkout@master


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/flexlogger-python/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Builds the PyPI package on Windows, not Ubuntu

### Why should this Pull Request be merged?

We're currently failing to build the PyPI package, this is an attempt to fix it

### What testing has been done?

None