### PR TITLE
Use "python" instead of "python3"

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -19,10 +19,10 @@ jobs:
           python-version: 3.8
 
       - name: Install setuptools and other tools
-        run: python3 -m pip install setuptools wheel twine grpcio grpcio-tools
+        run: python -m pip install setuptools wheel twine grpcio grpcio-tools
 
       - name: Build packages
-        run: python3 setup.py bdist_wheel
+        run: python setup.py bdist_wheel
 
       - name: Publish distribution to PyPI
         if: github.event.action == 'published'


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/flexlogger-python/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Since we're on Windows now, run with "python" instead of "python3".

### Why should this Pull Request be merged?

Attempt to fix publishing pypi package.

### What testing has been done?

None