### PR TITLE
More specifiers for pywin32

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,5 +6,5 @@ psutil
 # This package only works correctly on Windows,
 # but add this specifier to allow installing it on
 # Linux, which is helpful for pypi builds and readthedocs.
-pywin32; platform_system="Windows"
+pywin32; platform_system=="Windows"
 typing-extensions

--- a/setup.py
+++ b/setup.py
@@ -93,7 +93,10 @@ setup(
         "grpcio",
         "grpcio-tools",
         "psutil",
-        "pywin32",
+        # This package only works correctly on Windows,
+        # but add this specifier to allow installing it on
+        # Linux, which is helpful for pypi builds and readthedocs.
+        "pywin32; platform_system=='Windows'",
         "console-menu",
         "PrettyTable",
     ],


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/flexlogger-python/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Provides more specifiers for pywin32 so it won't get installed on Linux.

### Why should this Pull Request be merged?

Hopefully will fix readthedocs build.

### What testing has been done?

Can install on Windows.