### PR TITLE
Fix some errors when cleaning up test run in tox

### DIFF
--- a/tests/test_test_session.py
+++ b/tests/test_test_session.py
@@ -29,8 +29,14 @@ def project_with_produced_data(app: Application) -> Iterator[Project]:
 
     This is useful to improve test time by not opening/closing this project in every test.
     """
-    with open_project(app, "ProjectWithProducedData") as project:
+    with copy_project("ProjectWithProducedData") as project_path:
+        project = app.open_project(project_path)
         yield project
+        try:
+            project.close()
+        except FlexLoggerError:
+            # utils.kill_all_open_flexloggers may have killed this process already, that's fine
+            pass
 
 
 class TestTestSession:

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -83,7 +83,11 @@ def copy_project(project_name: str) -> Iterator[Path]:
     try:
         yield Path(tmp_directory.name) / project_filename
     finally:
-        rmtree(tmp_directory.name)
+        try:
+            rmtree(tmp_directory.name)
+        except PermissionError:
+            # this can fail because of race conditions, allow this
+            pass
 
 
 def _kill_proc_tree(


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/flexlogger-python/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

When running tests in tox there are some errors at the end of the run in test cleanup.  This PR fixes these errors.

There are still some warnings that are happening; I will address this in a separate PR.

### Why should this Pull Request be merged?

Makes it easier to see when tests are failing.

### What testing has been done?

Ran a full test run locally, there were only warnings and no errors at the end of the run.
