### PR TITLE
FlexLogger 2021 R3 Features: Pause/Resume test, Query project file lo…

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -15,7 +15,7 @@ Requirements
 ============
 **niflexlogger-automation** has the following requirements:
 
-* FlexLogger 2021 R1+
+* FlexLogger 2021 R3+
 * CPython 3.6 - 3.9
 
 .. _installation_section:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -47,6 +47,7 @@ exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 nitpicky = True
 nitpick_ignore = [
     ("py:class", "datetime.datetime"),
+    ("py:class", "datetime.timedelta"),
     ("py:class", "pathlib.Path"),
     ("py:data", "typing.Any"),
     ("py:data", "typing.Iterable"),

--- a/examples/Basic/get_project_file_path.py
+++ b/examples/Basic/get_project_file_path.py
@@ -5,7 +5,7 @@ from flexlogger.automation import Application
 
 
 def main(project_path):
-    """Launch FlexLogger, open a project, and gets the log file base path and name."""
+    """Launch FlexLogger, open a project, and get the loaded project's file path."""
     with Application.launch() as app:
         project = app.open_project(path=project_path)
         print("Project file path: " + str(project.project_file_path))

--- a/examples/Basic/get_project_file_path.py
+++ b/examples/Basic/get_project_file_path.py
@@ -1,0 +1,24 @@
+import os
+import sys
+
+from flexlogger.automation import Application
+
+
+def main(project_path):
+    """Launch FlexLogger, open a project, and gets the log file base path and name."""
+    with Application.launch() as app:
+        project = app.open_project(path=project_path)
+        print("Project file path: " + str(project.project_file_path))
+        print("Press Enter to close the project...")
+        input()
+        project.close()
+    return 0
+
+
+if __name__ == "__main__":
+    argv = sys.argv
+    if len(argv) < 2:
+        print("Usage: %s <path of project to open>" % os.path.basename(__file__))
+        sys.exit()
+    project_path_arg = argv[1]
+    sys.exit(main(project_path_arg))

--- a/examples/Basic/pause_and_resume_test_session.py
+++ b/examples/Basic/pause_and_resume_test_session.py
@@ -1,0 +1,32 @@
+import os
+import sys
+
+from flexlogger.automation import Application
+
+
+def main(project_path):
+    """Launch FlexLogger, open a project, pauses and resumes the test session."""
+    with Application.launch() as app:
+        project = app.open_project(path=project_path)
+        test_session = project.test_session
+        test_session.start()
+        print("Test started. Press Enter to pause the test...")
+        input()
+        test_session.pause()
+        print("Test paused. Press Enter to resume the test...")
+        input()
+        test_session.resume()
+        print("Test resumed. Press Enter to stop the test and close the project...")
+        input()
+        test_session.stop()
+        project.close()
+    return 0
+
+
+if __name__ == "__main__":
+    argv = sys.argv
+    if len(argv) < 2:
+        print("Usage: %s <path of project to open>" % os.path.basename(__file__))
+        sys.exit()
+    project_path_arg = argv[1]
+    sys.exit(main(project_path_arg))

--- a/examples/Interactive/manage_test_session.py
+++ b/examples/Interactive/manage_test_session.py
@@ -59,8 +59,10 @@ def _resume_test(test_session):
 
 def _monitor_test_time(test_session):
     print("Monitoring test time. Press [Enter] to stop monitoring. . .")
-    thread_exit_event =  threading.Event()
-    monitor_test_thread = threading.Thread(target=_monitor_test_time_thread,args=(test_session,thread_exit_event))
+    thread_exit_event = threading.Event()
+    monitor_test_thread = threading.Thread(
+        target=_monitor_test_time_thread, args=(test_session, thread_exit_event)
+    )
     monitor_test_thread.start()
     Screen().input()
     thread_exit_event.set()

--- a/protobuf/ConfigurationBasedSoftware/FlexLogger/Automation/FlexLogger.Automation.Protocols/Project.proto
+++ b/protobuf/ConfigurationBasedSoftware/FlexLogger/Automation/FlexLogger.Automation.Protocols/Project.proto
@@ -16,6 +16,8 @@ service Project {
   rpc OpenTestSpecificationDocument(OpenTestSpecificationDocumentRequest) returns (OpenTestSpecificationDocumentResponse) {}
   // RPC call to close the current project.
   rpc Close(CloseProjectRequest) returns (CloseProjectResponse) {}
+  // RPC call to query the file path of the current project.
+  rpc GetProjectFilePath(GetProjectFilePathRequest) returns (GetProjectFilePathResponse) {}
 }
 
 // Information necessary to open the channel specification document.
@@ -76,3 +78,15 @@ message CloseProjectRequest {
 
 // The result of the close project message.
 message CloseProjectResponse {}
+
+// Request object for getting the project file path
+message GetProjectFilePathRequest {
+    // Project envoy identifier
+    national_instruments.diagram_sdk.automation.protocols.ProjectIdentifier project = 1;
+}
+
+// Response object for a get project file path request
+message GetProjectFilePathResponse {
+    // The project file path
+    string project_file_path = 1;
+}

--- a/protobuf/ConfigurationBasedSoftware/FlexLogger/Automation/FlexLogger.Automation.Protocols/TestSession.proto
+++ b/protobuf/ConfigurationBasedSoftware/FlexLogger/Automation/FlexLogger.Automation.Protocols/TestSession.proto
@@ -14,6 +14,12 @@ service TestSession {
     rpc Start(StartTestSessionRequest) returns (StartTestSessionResponse) {}
     // RPC call to stop the test session.
     rpc Stop(StopTestSessionRequest) returns (StopTestSessionResponse) {}
+    // RPC call to pause the test session.
+    rpc Pause(PauseTestSessionRequest) returns (PauseTestSessionResponse) {}
+    // RPC call to resume the test session.
+    rpc Resume(ResumeTestSessionRequest) returns (ResumeTestSessionResponse) {}
+    // RPC call to query elapsed test time
+    rpc GetElapsedTestTime(GetElapsedTestTimeRequest) returns (GetElapsedTestTimeResponse) {}
 }
 
 // Request object for adding a note.
@@ -54,4 +60,34 @@ message StopTestSessionRequest {
 message StopTestSessionResponse {
     // Indicates if the test session was stopped
     bool test_session_stopped = 1;
+}
+
+// Request object for pausing the test session.
+message PauseTestSessionRequest {
+}
+
+// Response object for a pause test session request.
+message PauseTestSessionResponse {
+    // Indicates if the test session was paused
+    bool test_session_paused = 1;
+}
+
+// Request object for resuming the test session.
+message ResumeTestSessionRequest {
+}
+
+// Response object for a resume test session request.
+message ResumeTestSessionResponse {
+    // Indicates if the test session was resumed
+    bool test_session_resumed = 1;
+}
+
+// Request object for querying elapsed test time.
+message GetElapsedTestTimeRequest {
+}
+
+// Response object for querying elapsed test time request.
+message GetElapsedTestTimeResponse {
+    // Indicates the elapsed test time (in seconds)
+    double elapsed_test_time = 1;
 }

--- a/protobuf/ConfigurationBasedSoftware/FlexLogger/Automation/FlexLogger.Automation.Protocols/TestSessionState.proto
+++ b/protobuf/ConfigurationBasedSoftware/FlexLogger/Automation/FlexLogger.Automation.Protocols/TestSessionState.proto
@@ -5,10 +5,12 @@ package national_instruments.flex_logger.automation.protocols;
 enum TestSessionState {
   // The test session is idle and ready to start.
   TEST_SESSION_STATE_IDLE = 0;
-  // The test session is currently runnging.
+  // The test session is currently running.
   TEST_SESSION_STATE_RUNNING = 2;
   // The project has an invalid configuration. The test session cannot be started.
   TEST_SESSION_STATE_INVALID_CONFIGURATION = 3;
   // The project does not have any valid channels that can be logged. The test session cannot be started.
   TEST_SESSION_STATE_NO_VALID_LOGGED_CHANNELS = 4;
+  // The test session is currently paused.
+  TEST_SESSION_STATE_PAUSED = 5;
 }

--- a/setup.py
+++ b/setup.py
@@ -101,7 +101,7 @@ setup(
         "PrettyTable",
     ],
     setup_requires=["grpcio", "grpcio-tools"],
-    tests_require=["pytest", "mypy", "npTDMS"],
+    tests_require=["pytest", "mypy", "npTDMS", "pytest-timeout", "psutil"],
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "Intended Audience :: Developers",

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ def _get_version(name: str) -> str:
     script_dir = os.path.dirname(os.path.realpath(__file__))
     script_dir = os.path.join(script_dir, name)
     if not os.path.exists(os.path.join(script_dir, "VERSION")):
-        version = "0.1.0"
+        version = "0.1.1"
     else:
         with open(os.path.join(script_dir, "VERSION"), "r") as version_file:
             version = version_file.read().rstrip()

--- a/src/flexlogger/automation/_project.py
+++ b/src/flexlogger/automation/_project.py
@@ -1,3 +1,4 @@
+import pathlib
 from typing import Callable
 from typing import Optional
 
@@ -14,8 +15,6 @@ from .proto import (
     Project_pb2_grpc,  # type: ignore
 )
 from .proto.Identifiers_pb2 import ProjectIdentifier
-
-import pathlib
 
 
 class Project:

--- a/src/flexlogger/automation/_test_session.py
+++ b/src/flexlogger/automation/_test_session.py
@@ -157,7 +157,9 @@ class TestSession:
         """
         stub = TestSession_pb2_grpc.TestSessionStub(self._channel)
         try:
-            get_elapsed_test_time_response = stub.GetElapsedTestTime(TestSession_pb2.GetElapsedTestTimeRequest())
+            get_elapsed_test_time_response = stub.GetElapsedTestTime(
+                TestSession_pb2.GetElapsedTestTimeRequest()
+            )
             return timedelta(seconds=get_elapsed_test_time_response.elapsed_test_time)
         except (RpcError, ValueError) as error:
             self._raise_if_application_closed()

--- a/src/flexlogger/automation/_test_session.py
+++ b/src/flexlogger/automation/_test_session.py
@@ -10,6 +10,8 @@ from .proto import (
 )
 from .proto.TestSessionState_pb2 import TestSessionState as TestSessionState_pb2
 
+from datetime import timedelta
+
 STATE_MAP = {
     TestSessionState_pb2.TEST_SESSION_STATE_IDLE: TestSessionState.IDLE,
     TestSessionState_pb2.TEST_SESSION_STATE_RUNNING: TestSessionState.RUNNING,
@@ -19,6 +21,7 @@ STATE_MAP = {
     TestSessionState_pb2.TEST_SESSION_STATE_NO_VALID_LOGGED_CHANNELS: (
         TestSessionState.NO_VALID_LOGGED_CHANNELS
     ),
+    TestSessionState_pb2.TEST_SESSION_STATE_PAUSED: TestSessionState.PAUSED,
 }
 
 
@@ -63,10 +66,10 @@ class TestSession:
         self._raise_if_application_closed()
         stub = TestSession_pb2_grpc.TestSessionStub(self._channel)
         try:
-            getTestSessionStateResponse = stub.GetState(
+            get_test_session_state_response = stub.GetState(
                 TestSession_pb2.GetTestSessionStateRequest()
             )
-            state = STATE_MAP.get(getTestSessionStateResponse.test_session_state)
+            state = STATE_MAP.get(get_test_session_state_response.test_session_state)
             if state is None:
                 raise RuntimeError("The test session is in an undefined state.")
             return state
@@ -85,8 +88,8 @@ class TestSession:
         """
         stub = TestSession_pb2_grpc.TestSessionStub(self._channel)
         try:
-            startTestSessionResponse = stub.Start(TestSession_pb2.StartTestSessionRequest())
-            return startTestSessionResponse.test_session_started
+            start_test_session_response = stub.Start(TestSession_pb2.StartTestSessionRequest())
+            return start_test_session_response.test_session_started
         except (RpcError, ValueError) as error:
             self._raise_if_application_closed()
             raise FlexLoggerError("Failed to start test session") from error
@@ -102,8 +105,60 @@ class TestSession:
         """
         stub = TestSession_pb2_grpc.TestSessionStub(self._channel)
         try:
-            stopTestSessionResponse = stub.Stop(TestSession_pb2.StopTestSessionRequest())
-            return stopTestSessionResponse.test_session_stopped
+            stop_test_session_response = stub.Stop(TestSession_pb2.StopTestSessionRequest())
+            return stop_test_session_response.test_session_stopped
         except (RpcError, ValueError) as error:
             self._raise_if_application_closed()
             raise FlexLoggerError("Failed to stop test session") from error
+
+    def pause(self) -> bool:
+        """Pauses the test session, if possible.
+
+        Returns:
+            True if the test was paused, otherwise False.
+
+        Raises:
+            FlexLoggerError: if pausing the test session fails.
+        """
+        stub = TestSession_pb2_grpc.TestSessionStub(self._channel)
+        try:
+            pause_test_session_response = stub.Pause(TestSession_pb2.PauseTestSessionRequest())
+            return pause_test_session_response.test_session_paused
+        except (RpcError, ValueError) as error:
+            self._raise_if_application_closed()
+            raise FlexLoggerError("Failed to pause test session") from error
+
+    def resume(self) -> bool:
+        """Resumes the test session, if possible.
+
+        Returns:
+            True if the test was resumed, otherwise False.
+
+        Raises:
+            FlexLoggerError: if resuming the test session fails.
+        """
+        stub = TestSession_pb2_grpc.TestSessionStub(self._channel)
+        try:
+            resume_test_session_response = stub.Resume(TestSession_pb2.ResumeTestSessionRequest())
+            return resume_test_session_response.test_session_resumed
+        except (RpcError, ValueError) as error:
+            self._raise_if_application_closed()
+            raise FlexLoggerError("Failed to resume test session") from error
+
+    @property
+    def elapsed_test_time(self) -> timedelta:
+        """Queries the elapsed test time
+
+        Returns:
+            The current tests's elapsed time if a test is running or paused, the most recent test's elapsed time if a test has been run and stopped.
+
+        Raises:
+            FlexLoggerError: if no test has ever been run since the project was loaded
+        """
+        stub = TestSession_pb2_grpc.TestSessionStub(self._channel)
+        try:
+            get_elapsed_test_time_response = stub.GetElapsedTestTime(TestSession_pb2.GetElapsedTestTimeRequest())
+            return timedelta(seconds=get_elapsed_test_time_response.elapsed_test_time)
+        except (RpcError, ValueError) as error:
+            self._raise_if_application_closed()
+            raise FlexLoggerError("Failed to query elapsed test time") from error

--- a/src/flexlogger/automation/_test_session.py
+++ b/src/flexlogger/automation/_test_session.py
@@ -1,3 +1,4 @@
+from datetime import timedelta
 from typing import Callable
 
 from grpc import Channel, RpcError
@@ -9,8 +10,6 @@ from .proto import (
     TestSession_pb2_grpc,
 )
 from .proto.TestSessionState_pb2 import TestSessionState as TestSessionState_pb2
-
-from datetime import timedelta
 
 STATE_MAP = {
     TestSessionState_pb2.TEST_SESSION_STATE_IDLE: TestSessionState.IDLE,
@@ -150,7 +149,8 @@ class TestSession:
         """Queries the elapsed test time
 
         Returns:
-            The current tests's elapsed time if a test is running or paused, the most recent test's elapsed time if a test has been run and stopped.
+            The current tests's elapsed time if a test is running or paused,
+            the most recent test's elapsed time if a test has been run and stopped.
 
         Raises:
             FlexLoggerError: if no test has ever been run since the project was loaded

--- a/src/flexlogger/automation/_test_session_state.py
+++ b/src/flexlogger/automation/_test_session_state.py
@@ -12,7 +12,7 @@ class TestSessionState(Enum):
 
     RUNNING = 2
     """The :class:`.TestSession` is running.
-    
+
     Logging and events are active while the test session is running.
 
     Configuration changes are not allowed when the test session is running.
@@ -26,7 +26,7 @@ class TestSessionState(Enum):
 
     PAUSED = 5
     """The :class:`.TestSession` is paused.
-    
+
     Logging and events are not active while the test session is paused.
 
     Configuration changes are not allowed when the test session is paused.

--- a/src/flexlogger/automation/_test_session_state.py
+++ b/src/flexlogger/automation/_test_session_state.py
@@ -11,9 +11,11 @@ class TestSessionState(Enum):
     """
 
     RUNNING = 2
-    """The :class:`.TestSession` is logging.
+    """The :class:`.TestSession` is running.
+    
+    Logging and events are active while the test session is running.
 
-    Configuration changes are not allowed during this state.
+    Configuration changes are not allowed when the test session is running.
     """
 
     INVALID_CONFIGURATION = 3
@@ -21,3 +23,11 @@ class TestSessionState(Enum):
 
     NO_VALID_LOGGED_CHANNELS = 4
     """No channels have been configured, or all channels are disabled or not available."""
+
+    PAUSED = 5
+    """The :class:`.TestSession` is paused.
+    
+    Logging and events are not active while the test session is paused.
+
+    Configuration changes are not allowed when the test session is paused.
+    """

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -1,6 +1,5 @@
 from shutil import rmtree
 from time import sleep
-from pathlib import Path
 
 import pytest  # type: ignore
 from flexlogger.automation import Application, FlexLoggerError

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -1,5 +1,6 @@
 from shutil import rmtree
 from time import sleep
+from pathlib import Path
 
 import pytest  # type: ignore
 from flexlogger.automation import Application, FlexLoggerError
@@ -11,7 +12,6 @@ from .utils import (
     kill_all_open_flexloggers,
     open_project,
 )
-
 
 class TestProject:
     @pytest.mark.integration  # type: ignore
@@ -239,3 +239,10 @@ class TestProject:
                 logging_specification.set_log_file_name("SomeNewName")
         # Just verify that closing the app doesn't prompt to save the project (this test
         # will timeout if it does)
+
+    @pytest.mark.integration
+    def test__open_project__active_project_path_matches_loaded_path(self) -> None:
+        with copy_project("DefaultProject") as new_project_path:
+            with Application.launch() as app:
+                project = app.open_project(new_project_path)
+                assert project.project_file_path == new_project_path

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -13,6 +13,7 @@ from .utils import (
     open_project,
 )
 
+
 class TestProject:
     @pytest.mark.integration  # type: ignore
     def test__launch_flexLogger__open_default_project__project_contains_standard_four_documents(

--- a/tests/test_test_session.py
+++ b/tests/test_test_session.py
@@ -321,7 +321,9 @@ class TestTestSession:
             assert second_elapsed_time_after_pause == first_elapsed_time_after_pause
 
     @pytest.mark.integration  # type: ignore
-    def test__test_session_stopped__elapsed_time_returns_previous_test_session_elapsed_time(self, app: Application) -> None:
+    def test__test_session_stopped__elapsed_time_returns_previous_test_session_elapsed_time(
+        self, app: Application
+    ) -> None:
         with open_project(app, "ProjectWithProducedData") as project:
             project.test_session.start()
             time.sleep(0.25)
@@ -335,7 +337,9 @@ class TestTestSession:
             assert elapsed_time_after_stop > elapsed_time_before_stop
 
     @pytest.mark.integration  # type: ignore
-    def test__test_session_stopped__start_new_test__elapsed_time_resets(self, app: Application) -> None:
+    def test__test_session_stopped__start_new_test__elapsed_time_resets(
+        self, app: Application
+    ) -> None:
         with open_project(app, "ProjectWithProducedData") as project:
             project.test_session.start()
             time.sleep(2.0)

--- a/tests/test_test_session.py
+++ b/tests/test_test_session.py
@@ -56,9 +56,7 @@ class TestTestSession:
             assert expected_state == project.test_session.state
 
     @pytest.mark.integration  # type: ignore
-    @pytest.mark.parametrize(
-        "project_name", [("DefaultProject"), ("ProjectWithError")]
-    )  # type: ignore
+    @pytest.mark.parametrize("project_name", ["DefaultProject", "ProjectWithError"])  # type: ignore
     def test__open_project_that_cannot_be_started__start_test_session__exception_raised(
         self, project_name: str, app: Application
     ) -> None:
@@ -115,6 +113,87 @@ class TestTestSession:
         assert TestSessionState.IDLE == project.test_session.state
 
     @pytest.mark.integration  # type: ignore
+    def test__test_session_running__pause_test_session__test_session_paused(
+        self, app: Application, project_with_produced_data: Project
+    ) -> None:
+        project = project_with_produced_data
+        project.test_session.start()
+        test_session_paused = project.test_session.pause()
+        try:
+            assert test_session_paused is True
+            assert TestSessionState.PAUSED == project.test_session.state
+        finally:
+            project.test_session.stop()
+
+    @pytest.mark.integration  # type: ignore
+    def test__test_session_paused__resume_test_session__test_session_resumes(
+        self, app: Application, project_with_produced_data: Project
+    ) -> None:
+        project = project_with_produced_data
+        project.test_session.start()
+        project.test_session.pause()
+        test_session_resumed = project.test_session.resume()
+        try:
+            assert test_session_resumed is True
+            assert TestSessionState.RUNNING == project.test_session.state
+        finally:
+            project.test_session.stop()
+
+    @pytest.mark.integration  # type: ignore
+    def test__test_session_paused__pause_test_session__test_session_remains_paused(
+        self, app: Application, project_with_produced_data: Project
+    ) -> None:
+        project = project_with_produced_data
+        project.test_session.start()
+        project.test_session.pause()
+        test_session_paused = project.test_session.pause()
+        try:
+            assert test_session_paused is False
+            assert TestSessionState.PAUSED == project.test_session.state
+        finally:
+            project.test_session.stop()
+
+    @pytest.mark.integration  # type: ignore
+    def test__test_session_running__resume_test_session__test_session_remains_running(
+        self, app: Application, project_with_produced_data: Project
+    ) -> None:
+        project = project_with_produced_data
+        project.test_session.start()
+        test_session_resumed = project.test_session.resume()
+        try:
+            assert test_session_resumed is False
+            assert TestSessionState.RUNNING == project.test_session.state
+        finally:
+            project.test_session.stop()
+
+    @pytest.mark.integration  # type: ignore
+    def test__test_session_paused__stop_test_session__test_session_stopped(
+        self, app: Application, project_with_produced_data: Project
+    ) -> None:
+        project = project_with_produced_data
+        project.test_session.start()
+        project.test_session.pause()
+
+        stopped = project.test_session.stop()
+
+        assert stopped is True
+        assert TestSessionState.IDLE == project.test_session.state
+
+    @pytest.mark.integration  # type: ignore
+    def test__open_valid_project__pause_test_session__exception_raised(
+        self, app: Application, project_with_produced_data: Project
+    ) -> None:
+        with pytest.raises(FlexLoggerError):
+            project_with_produced_data.test_session.pause()
+
+    @pytest.mark.integration  # type: ignore
+    def test__open_valid_project__resume_test_session__exception_raised(
+        self, app: Application, project_with_produced_data: Project
+    ) -> None:
+        with pytest.raises(FlexLoggerError):
+            project_with_produced_data.test_session.resume()
+
+    @pytest.mark.integration  # type: ignore
     def test__test_session_running__add_note__note_added(self, app: Application) -> None:
         with open_project(app, "ProjectWithProducedData") as project:
             logging_specification = project.open_logging_specification_document()
@@ -129,8 +208,25 @@ class TestTestSession:
                 project.test_session.stop()
                 self._verify_tdms_file_has_note(temp_dir, "AddNoteTest.tdms", note_str)
 
+    @pytest.mark.integration  # type: ignore
+    def test__test_session_paused__add_note__note_added(self, app: Application) -> None:
+        with open_project(app, "ProjectWithProducedData") as project:
+            logging_specification = project.open_logging_specification_document()
+            with TemporaryDirectory() as temp_dir:
+                logging_specification.set_log_file_base_path(temp_dir)
+                logging_specification.set_log_file_name("AddNoteTest.tdms")
+                project.test_session.start()
+                project.test_session.pause()
+
+                note_str = "Some note about what is happening in the test"
+                project.test_session.add_note(note_str)
+
+                project.test_session.stop()
+                self._verify_tdms_file_has_note(temp_dir, "AddNoteTest.tdms", note_str)
+
+    @staticmethod
     def _verify_tdms_file_has_note(
-        self, log_file_base_path: str, log_file_name: str, expected_note_contents: str
+        log_file_base_path: str, log_file_name: str, expected_note_contents: str
     ) -> None:
         log_file_path = Path(log_file_base_path) / log_file_name
         with TdmsFile.open(str(log_file_path)) as tdms_file:
@@ -188,3 +284,64 @@ class TestTestSession:
                     kill_all_open_flexloggers()
                     if process is not None:
                         process.kill()
+
+    @pytest.mark.integration  # type: ignore
+    def test__test_session_idle__query_elapsed_time__exception_raised(
+        self, app: Application, project_with_produced_data: Project
+    ) -> None:
+        with pytest.raises(FlexLoggerError):
+            project_with_produced_data.test_session.elapsed_test_time
+
+    @pytest.mark.integration  # type: ignore
+    def test__test_session_running__elapsed_time_increases(self, app: Application) -> None:
+        with open_project(app, "ProjectWithProducedData") as project:
+            project.test_session.start()
+
+            time.sleep(0.25)
+            first_elapsed_time = project.test_session.elapsed_test_time
+            assert first_elapsed_time.total_seconds() > 0
+            time.sleep(0.25)
+            second_elapsed_time = project.test_session.elapsed_test_time
+            assert second_elapsed_time > first_elapsed_time
+
+    @pytest.mark.integration  # type: ignore
+    def test__test_session_paused__elapsed_time_pauses(self, app: Application) -> None:
+        with open_project(app, "ProjectWithProducedData") as project:
+            project.test_session.start()
+            time.sleep(0.25)
+            elapsed_time_before_pause = project.test_session.elapsed_test_time
+            assert elapsed_time_before_pause.total_seconds() > 0
+            project.test_session.pause()
+
+            time.sleep(0.25)
+            first_elapsed_time_after_pause = project.test_session.elapsed_test_time
+            assert first_elapsed_time_after_pause > elapsed_time_before_pause
+            time.sleep(0.25)
+            second_elapsed_time_after_pause = project.test_session.elapsed_test_time
+            assert second_elapsed_time_after_pause == first_elapsed_time_after_pause
+
+    @pytest.mark.integration  # type: ignore
+    def test__test_session_stopped__elapsed_time_returns_previous_test_session_elapsed_time(self, app: Application) -> None:
+        with open_project(app, "ProjectWithProducedData") as project:
+            project.test_session.start()
+            time.sleep(0.25)
+            elapsed_time_before_stop = project.test_session.elapsed_test_time
+            assert elapsed_time_before_stop.total_seconds() > 0
+            time.sleep(0.25)
+            project.test_session.stop()
+
+            time.sleep(0.25)
+            elapsed_time_after_stop = project.test_session.elapsed_test_time
+            assert elapsed_time_after_stop > elapsed_time_before_stop
+
+    @pytest.mark.integration  # type: ignore
+    def test__test_session_stopped__start_new_test__elapsed_time_resets(self, app: Application) -> None:
+        with open_project(app, "ProjectWithProducedData") as project:
+            project.test_session.start()
+            time.sleep(2.0)
+            project.test_session.stop()
+            first_test_session_time = project.test_session.elapsed_test_time
+
+            project.test_session.start()
+            second_test_session_time = project.test_session.elapsed_test_time
+            assert second_test_session_time < first_test_session_time

--- a/tests/test_test_session.py
+++ b/tests/test_test_session.py
@@ -285,67 +285,76 @@ class TestTestSession:
                     if process is not None:
                         process.kill()
 
+
+class TestTestSessionElapsedTime:
     @pytest.mark.integration  # type: ignore
     def test__test_session_idle__query_elapsed_time__exception_raised(
+        self, app: Application
+    ) -> None:
+        with open_project(app, "ProjectWithProducedData") as project:
+            with pytest.raises(FlexLoggerError):
+                project.test_session.elapsed_test_time
+
+    @pytest.mark.integration  # type: ignore
+    def test__test_session_running__elapsed_time_increases(
         self, app: Application, project_with_produced_data: Project
     ) -> None:
-        with pytest.raises(FlexLoggerError):
-            project_with_produced_data.test_session.elapsed_test_time
+        project = project_with_produced_data
+        project.test_session.start()
+
+        time.sleep(0.25)
+        first_elapsed_time = project.test_session.elapsed_test_time
+        assert first_elapsed_time.total_seconds() > 0
+        time.sleep(0.25)
+        second_elapsed_time = project.test_session.elapsed_test_time
+        assert second_elapsed_time > first_elapsed_time
 
     @pytest.mark.integration  # type: ignore
-    def test__test_session_running__elapsed_time_increases(self, app: Application) -> None:
-        with open_project(app, "ProjectWithProducedData") as project:
-            project.test_session.start()
+    def test__test_session_paused__elapsed_time_pauses(
+        self, app: Application, project_with_produced_data: Project
+    ) -> None:
+        project = project_with_produced_data
+        project.test_session.start()
+        time.sleep(0.25)
+        elapsed_time_before_pause = project.test_session.elapsed_test_time
+        assert elapsed_time_before_pause.total_seconds() > 0
+        project.test_session.pause()
 
-            time.sleep(0.25)
-            first_elapsed_time = project.test_session.elapsed_test_time
-            assert first_elapsed_time.total_seconds() > 0
-            time.sleep(0.25)
-            second_elapsed_time = project.test_session.elapsed_test_time
-            assert second_elapsed_time > first_elapsed_time
-
-    @pytest.mark.integration  # type: ignore
-    def test__test_session_paused__elapsed_time_pauses(self, app: Application) -> None:
-        with open_project(app, "ProjectWithProducedData") as project:
-            project.test_session.start()
-            time.sleep(0.25)
-            elapsed_time_before_pause = project.test_session.elapsed_test_time
-            assert elapsed_time_before_pause.total_seconds() > 0
-            project.test_session.pause()
-
-            time.sleep(0.25)
-            first_elapsed_time_after_pause = project.test_session.elapsed_test_time
-            assert first_elapsed_time_after_pause > elapsed_time_before_pause
-            time.sleep(0.25)
-            second_elapsed_time_after_pause = project.test_session.elapsed_test_time
-            assert second_elapsed_time_after_pause == first_elapsed_time_after_pause
+        time.sleep(0.25)
+        first_elapsed_time_after_pause = project.test_session.elapsed_test_time
+        assert first_elapsed_time_after_pause > elapsed_time_before_pause
+        time.sleep(0.25)
+        second_elapsed_time_after_pause = project.test_session.elapsed_test_time
+        assert second_elapsed_time_after_pause == first_elapsed_time_after_pause
+        project.test_session.stop()
 
     @pytest.mark.integration  # type: ignore
     def test__test_session_stopped__elapsed_time_returns_previous_test_session_elapsed_time(
-        self, app: Application
+        self, app: Application, project_with_produced_data: Project
     ) -> None:
-        with open_project(app, "ProjectWithProducedData") as project:
-            project.test_session.start()
-            time.sleep(0.25)
-            elapsed_time_before_stop = project.test_session.elapsed_test_time
-            assert elapsed_time_before_stop.total_seconds() > 0
-            time.sleep(0.25)
-            project.test_session.stop()
+        project = project_with_produced_data
+        project.test_session.start()
+        time.sleep(0.25)
+        elapsed_time_before_stop = project.test_session.elapsed_test_time
+        assert elapsed_time_before_stop.total_seconds() > 0
+        time.sleep(0.25)
+        project.test_session.stop()
 
-            time.sleep(0.25)
-            elapsed_time_after_stop = project.test_session.elapsed_test_time
-            assert elapsed_time_after_stop > elapsed_time_before_stop
+        time.sleep(0.25)
+        elapsed_time_after_stop = project.test_session.elapsed_test_time
+        assert elapsed_time_after_stop > elapsed_time_before_stop
 
     @pytest.mark.integration  # type: ignore
     def test__test_session_stopped__start_new_test__elapsed_time_resets(
-        self, app: Application
+        self, app: Application, project_with_produced_data: Project
     ) -> None:
-        with open_project(app, "ProjectWithProducedData") as project:
-            project.test_session.start()
-            time.sleep(2.0)
-            project.test_session.stop()
-            first_test_session_time = project.test_session.elapsed_test_time
+        project = project_with_produced_data
+        project.test_session.start()
+        time.sleep(2.0)
+        project.test_session.stop()
+        first_test_session_time = project.test_session.elapsed_test_time
 
-            project.test_session.start()
-            second_test_session_time = project.test_session.elapsed_test_time
-            assert second_test_session_time < first_test_session_time
+        project.test_session.start()
+        second_test_session_time = project.test_session.elapsed_test_time
+        assert second_test_session_time < first_test_session_time
+        project.test_session.stop()

--- a/tox.ini
+++ b/tox.ini
@@ -19,9 +19,10 @@ deps =
     pytest
     npTDMS
     pytest-timeout
+    psutil
 changedir = src
 commands =
-    py39: black --target-version py36 --exclude "flexlogger/automation/proto/*" --check flexlogger ../examples ../tests
+    py39: black --target-version py36 --exclude "flexlogger\/automation\/proto\/" --check flexlogger ../examples ../tests
     py39: flake8 flexlogger ../examples/Basic ../examples/Interactive ../tests
     py39: mypy --config-file ../mypy.ini -p flexlogger.automation
     # We don't annotate types in our examples (to make them easier to read),


### PR DESCRIPTION
…cation, Query elapsed test time

- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niflexlogger-automation-python/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Adds Test Pause/Resume functionality
Adds the ability to query a loaded project's file path
Adds the ability to query elapsed test time while a test is running/paused, or to query the most recent test run's total elapsed time after the test has been stopped.

### Why should this Pull Request be merged?

To add the aforementioned functionality

### What testing has been done?
- [x] I have run the automated tests (required if there are code changes)