### PR TITLE
Update conf.py

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -73,5 +73,3 @@ html_theme = "sphinx_rtd_theme"
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = []
-
-html_codeblock_linenos_style = "table"

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -73,3 +73,5 @@ html_theme = "sphinx_rtd_theme"
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = []
+
+html_codeblock_linenos_style = "table"

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
 sphinx >= 2.1
 sphinx-autodoc-typehints
-sphinx-rtd-theme
+sphinx-rtd-theme >= 1.0.0rc1
 .


### PR DESCRIPTION
~~Set linenos style to "table" so that when you select code to copy/paste, it doesn't include the line numbers.~~
Bump **sphinx-rtd-theme** dependency version to a prerelease version that doesn't include line numbers when you text from the example code blocks.

- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/flexlogger-python/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Separates the code from the line numbers in our readthedocs documentation.

### Why should this Pull Request be merged?

We've been doing usability studies re: the python API and every user has ended up here: https://niflexlogger-automation.readthedocs.io/en/latest/getting_started.html#examples

When they try to copy/paste the code, it includes line numbers. When they go to delete them, the indentation gets messed up, and python cares a lot about indendtation.

### What testing has been done?

Ran `tox -e docs` on my machine and it looks good now.
Before:
![image](https://user-images.githubusercontent.com/83376129/131548919-4986f879-e44a-4909-a0f2-d50e73dfbce6.png)

After:
![image](https://user-images.githubusercontent.com/83376129/131549058-7672d491-1a4a-457b-b55a-519867fd4810.png)
