### PR TITLE
Add support for Python 3.10 and fix test.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -15,8 +15,8 @@ Requirements
 ============
 **niflexlogger-automation** has the following requirements:
 
-* FlexLogger 2021 R3+
-* CPython 3.6 - 3.9. If you do not have Python installed on your computer, go to python.org/downloads to download and install it.
+* FlexLogger 2022 Q2+
+* CPython 3.6 - 3.10. If you do not have Python installed on your computer, go to python.org/downloads to download and install it.
 
 .. _installation_section:
 

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -10,7 +10,7 @@ Prerequisites
 -------------
 
 Before using the FlexLogger Python API, complete the following tasks.
-  * Install FlexLogger 2021 R3 or later and create a FlexLogger project with one or more input channels.
+  * Install FlexLogger 2022 Q2 or later and create a FlexLogger project with one or more input channels.
   * Enable the Automation server preference in FlexLogger. In FlexLogger, navigate to **File>>Preferences** and check **Enable FlexLogger to receive remote automation commands** in the Automation server section of the General tab.
   * Download and install Python 3.6 or later from python.org/downloads. For more information on installing and using Python, refer to the Python documentation on `docs.python.org <https://docs.python.org/3/>`_. During installation, enable **Add Python to PATH** so you can execute Python commands more easily.
   * Install the FlexLogger Automation Python module, ``niflexlogger-automation``, using the method described below or one of the methods described in the `Readme <https://github.com/ni/niflexlogger-automation-python#readme>`_.
@@ -50,7 +50,7 @@ Use the Start and Stop a Test example code to automate a FlexLogger test. The st
    ``cd C:\Users\Desktop``
 7. Run the script with the ``python`` command. The Start and Stop a Test example requires that you provide the path to the project you want to control as an input. Use quotation marks when specifying the path. For example,
 
-   ``python my_script.py “C:\Users\Desktop\my_FlexLogger_Project.flxproj”``
+   ``python my_script.py "C:\Users\Desktop\my_FlexLogger_Project.flxproj"``
 
    The Python script launches FlexLogger, opens the project you specified, and starts running a test. The command prompt displays a status message and provides you with the option to stop the test and close the project.
 

--- a/examples/README.rst
+++ b/examples/README.rst
@@ -15,8 +15,8 @@ The Python Examples folder includes the following types of examples:
 
 Requirements
 ============
-* FlexLogger 2021 R3 or later
-* Python 3.6-3.9
+* FlexLogger 2022 Q2 or later
+* Python 3.6-3.10
 * pymodbus 2.5.3 (Only for the Thermal Chamber with Communication Protocol example)
 * numpy 1.0 (Only for the Thermal Chamber with Communication Protocol example)
 

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ def _get_version(name: str) -> str:
     script_dir = os.path.dirname(os.path.realpath(__file__))
     script_dir = os.path.join(script_dir, name)
     if not os.path.exists(os.path.join(script_dir, "VERSION")):
-        version = "0.1.2"
+        version = "0.1.3"
     else:
         with open(os.path.join(script_dir, "VERSION"), "r") as version_file:
             version = version_file.read().rstrip()
@@ -113,6 +113,7 @@ setup(
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: Implementation :: CPython",
         "Topic :: Scientific/Engineering",
         "Topic :: System :: Hardware",

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -1,6 +1,7 @@
 from shutil import rmtree
 from time import sleep
 
+import os
 import pytest  # type: ignore
 from flexlogger.automation import Application, FlexLoggerError
 
@@ -245,4 +246,4 @@ class TestProject:
         with copy_project("DefaultProject") as new_project_path:
             with Application.launch() as app:
                 project = app.open_project(new_project_path)
-                assert project.project_file_path == new_project_path
+                assert os.path.samefile(project.project_file_path, new_project_path)

--- a/tox.ini
+++ b/tox.ini
@@ -4,17 +4,17 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py39,py38,py37,py36
+envlist = py310,py39,py38,py37,py36
 requires =
     setuptools >= 40.1.0
 
 [testenv]
 deps =
-    py39: black
-    py39: docutils
-    py39: flake8
-    py39: flake8-docstrings
-    py39: flake8-import-order
+    py310: black
+    py310: docutils
+    py310: flake8
+    py310: flake8-docstrings
+    py310: flake8-import-order
     mypy
     pytest
     npTDMS
@@ -22,13 +22,13 @@ deps =
     psutil
 changedir = src
 commands =
-    py39: black --target-version py36 --exclude "flexlogger\/automation\/proto\/" --check flexlogger ../examples ../tests
-    py39: flake8 flexlogger ../examples/Basic ../examples/Interactive ../tests
-    py39: mypy --config-file ../mypy.ini -p flexlogger.automation
+    py310: black --target-version py36 --exclude "flexlogger\/automation\/proto\/" --check flexlogger ../examples ../tests
+    py310: flake8 flexlogger ../examples/Basic ../examples/Interactive ../tests
+    py310: mypy --config-file ../mypy.ini -p flexlogger.automation
     # We don't annotate types in our examples (to make them easier to read),
     # but do check that we're using types correctly
-    py39: mypy --config-file ../mypy.ini --allow-untyped-defs --allow-incomplete-defs ../examples/Basic ../examples/Interactive
-    py39: mypy --config-file ../mypy.ini ../tests
+    py310: mypy --config-file ../mypy.ini --allow-untyped-defs --allow-incomplete-defs ../examples/Basic ../examples/Interactive
+    py310: mypy --config-file ../mypy.ini ../tests
     pytest --doctest-modules flexlogger
     pytest ../tests --strict-markers {posargs:-m "(not slow)"}
 # WINDIR environment variable needs to be set or FlexLogger
@@ -43,6 +43,7 @@ python =
    3.7: py37
    3.8: py38
    3.9: py39
+   3.10: py310
 
 # Note that pytest args can be passed on the commandline after "--", e.g.
 #    tox -- -m integration


### PR DESCRIPTION
- [X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/flexlogger-python/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

- Add support for Python 3.10 in setup.py and tox.ini
- Fix test_project:test__open_project__active_project_path_matches_loaded_path that was failing when the user name was too long.

### What testing has been done?

- Ran tox with Python 3.10
- Manual test of the API functions.

- [X] I have run the automated tests (required if there are code changes)