### PR TITLE
Enable users to get the project name from the python API

### DIFF
--- a/examples/Basic/get_project_file_path.py
+++ b/examples/Basic/get_project_file_path.py
@@ -9,6 +9,7 @@ def main(project_path):
     with Application.launch() as app:
         project = app.open_project(path=project_path)
         print("Project file path: " + str(project.project_file_path))
+        print("Project name: " + project.project_name)
         print("Press Enter to close the project...")
         input()
         project.close()

--- a/src/flexlogger/automation/_project.py
+++ b/src/flexlogger/automation/_project.py
@@ -1,3 +1,4 @@
+import os.path
 import pathlib
 from typing import Callable
 from typing import Optional
@@ -175,3 +176,13 @@ class Project:
         except (RpcError, ValueError) as error:
             self._raise_if_application_closed()
             raise FlexLoggerError("Failed to get project file path") from error
+
+    @property
+    def project_name(self) -> Optional[str]:
+        """Get the project name
+
+        Returns: The project name if the file path exists, None otherwise
+        """
+        project_path = self.project_file_path
+
+        return os.path.basename(os.path.splitext(project_path)[0])


### PR DESCRIPTION
- [X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/flexlogger-python/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Enable users to get the project name from the python API with a new project_name property on the project.


### Why should this Pull Request be merged?

Feature 2367473: Enable users to get the project name from the python API
The corresponding change has been approved and submitted to our private branch.

### What testing has been done?

Manual tests.

- [X] I have run the automated tests (required if there are code changes)