### PR TITLE
Add readthedocs configuration file and fix errors preventing doc build.

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,22 @@
+# Read the Docs configuration file for Sphinx projects
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Set the OS, Python version and other tools you might need
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.10"
+
+# Build documentation in the "docs/" directory with Sphinx
+sphinx:
+  configuration: docs/conf.py
+
+# Optional but recommended, declare the Python requirements required
+# to build your documentation
+# See https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
+python:
+   install:
+   - requirements: docs/requirements.txt

--- a/src/flexlogger/automation/_channel_specification_document.py
+++ b/src/flexlogger/automation/_channel_specification_document.py
@@ -252,6 +252,7 @@ class ChannelSpecificationDocument:
     def set_data_rate_level(self, channel_name: str, data_rate_level: DataRateLevel) -> None:
         """Set the data rate level of the specified channel
            Note: This may affect other channels in the same module or chassis set to the same data rate level.
+
         Args:
             channel_name: The name of the channel.
             data_rate_level: The data rate level to set.

--- a/src/flexlogger/automation/_events.py
+++ b/src/flexlogger/automation/_events.py
@@ -41,7 +41,7 @@ class FlexLoggerEventHandler:
     def __exit__(self, *args):
         self.unregister_from_events()
 
-    def get_registered_events(self):
+    def get_registered_events(self) -> list[EventType]:
         """Gets the list of registered event types.
 
         Returns

--- a/src/flexlogger/automation/_events.py
+++ b/src/flexlogger/automation/_events.py
@@ -41,7 +41,7 @@ class FlexLoggerEventHandler:
     def __exit__(self, *args):
         self.unregister_from_events()
 
-    def get_registered_events(self) -> [EventType]:
+    def get_registered_events(self):
         """Gets the list of registered event types.
 
         Returns


### PR DESCRIPTION
- [X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/flexlogger-python/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

My latest PR triggered a readthedocs build that failed
https://readthedocs.org/projects/niflexlogger-automation/builds/22109507/
This is because readthedocs now requires a configuration file as of September 2023 and we didn't have any.
This PR adds the configuration file and fixes docstrings errors I was getting in a couple files when trying to build locally.
See https://docs.readthedocs.io/en/stable/config-file/v2.html
I followed this [tutorial](https://docs.readthedocs.io/en/stable/config-file/index.html) to create the configuration file.

### Why should this Pull Request be merged?

This PR enabled the automatic build of the readthedocs documentation when a PR is submitted.

### What testing has been done?

Verified a local build works by running
`tox -e docs`

- [ ] I have run the automated tests (required if there are code changes)
No code changes that affect functionality.