### PR TITLE
Add functions to get and set the trigger settings in the logging specification document and support of a timeout when opening a project.

### DIFF
--- a/examples/Basic/get_trigger_settings.py
+++ b/examples/Basic/get_trigger_settings.py
@@ -1,0 +1,46 @@
+import os
+import sys
+
+from flexlogger.automation import Application
+from flexlogger.automation import StartTriggerCondition
+from flexlogger.automation import StopTriggerCondition
+
+
+def main(project_path):
+    """Launch FlexLogger, open a project, and get the trigger settings."""
+    with Application.launch() as app:
+        project = app.open_project(path=project_path)
+        logging_specification = project.open_logging_specification_document()
+
+        # Get and print the start trigger settings
+        start_trigger_condition, start_trigger_settings = logging_specification.get_start_trigger_settings()
+        print("Start Trigger Condition: " + str(start_trigger_condition))
+        if start_trigger_condition == StartTriggerCondition.CHANNEL_VALUE_CHANGE:
+            print("Channel Value Change Condition :")
+            print(start_trigger_settings)
+        elif start_trigger_condition == StartTriggerCondition.ABSOLUTE_TIME:
+            print("Start Time: " + start_trigger_settings.strftime("%x, %X"))
+
+        # Get and print the stop trigger settings
+        stop_trigger_condition, stop_trigger_settings = logging_specification.get_stop_trigger_settings()
+        print("Stop Trigger Condition: " + str(stop_trigger_condition))
+        if stop_trigger_condition == StopTriggerCondition.CHANNEL_VALUE_CHANGE:
+            print("Channel Value Change Condition :")
+            print(stop_trigger_settings)
+        elif stop_trigger_condition == StopTriggerCondition.TEST_TIME_ELAPSED:
+            print("Time Elapsed: " + stop_trigger_settings)
+
+        print("Press Enter to close the project...")
+        input()
+        project.close()
+
+    return 0
+
+
+if __name__ == "__main__":
+    argv = sys.argv
+    if len(argv) < 2:
+        print("Usage: %s <path of project to open>" % os.path.basename(__file__))
+        sys.exit()
+    project_path_arg = argv[1]
+    sys.exit(main(project_path_arg))

--- a/examples/Basic/launch_application.py
+++ b/examples/Basic/launch_application.py
@@ -10,7 +10,7 @@ def main(project_path):
     # goes out of scope, the application will be closed.  To prevent this,
     # call app.disconnect() before the scope ends.
     with Application.launch() as app:
-        project = app.open_project(path=project_path)
+        project = app.open_project(path=project_path, timeout=180)
         print("Press Enter to close project...")
         input()
         project.close()

--- a/examples/Basic/set_time_trigger_settings.py
+++ b/examples/Basic/set_time_trigger_settings.py
@@ -1,0 +1,36 @@
+import os
+import sys
+
+from datetime import datetime
+from datetime import timedelta
+from flexlogger.automation import Application
+
+
+def main(project_path):
+    """Launch FlexLogger, open a project, and set the trigger settings."""
+    with Application.launch() as app:
+        project = app.open_project(path=project_path)
+        logging_specification = project.open_logging_specification_document()
+
+        # Set the start trigger settings.
+        # test_start_time is treated as UTC unless a timezone is explicitly specified
+        test_start_time = datetime.utcnow()
+        logging_specification.set_start_trigger_settings_to_absolute_time(test_start_time)
+        # Set the stop trigger settings
+        duration = timedelta(seconds=100)
+        logging_specification.set_stop_trigger_settings_to_duration(duration)
+
+        print("Press Enter to close the project...")
+        input()
+        project.close()
+
+    return 0
+
+
+if __name__ == "__main__":
+    argv = sys.argv
+    if len(argv) < 2:
+        print("Usage: %s <path of project to open>" % os.path.basename(__file__))
+        sys.exit()
+    project_path_arg = argv[1]
+    sys.exit(main(project_path_arg))

--- a/examples/Basic/set_value_change_trigger_settings.py
+++ b/examples/Basic/set_value_change_trigger_settings.py
@@ -1,0 +1,44 @@
+import os
+import sys
+
+from flexlogger.automation import Application
+from flexlogger.automation import ValueChangeCondition
+from flexlogger.automation import ValueChangeType
+
+
+def main(project_path):
+    """Launch FlexLogger, open a project, and set the trigger settings."""
+    with Application.launch() as app:
+        project = app.open_project(path=project_path)
+        logging_specification = project.open_logging_specification_document()
+
+        start_value_change_condition = ValueChangeCondition()
+        start_value_change_condition.value_change_type = ValueChangeType.ENTER_RANGE
+        start_value_change_condition.channel_name = 'Replace this string with the channel name to monitor.'
+        start_value_change_condition.min_value = 1.0
+        start_value_change_condition.max_value = 2.0
+        start_value_change_condition.time = 0.0
+
+        stop_value_change_condition = ValueChangeCondition()
+        stop_value_change_condition.value_change_type = ValueChangeType.FALL_BELOW_VALUE
+        stop_value_change_condition.channel_name = 'Replace this string with the channel name to monitor.'
+        stop_value_change_condition.threshold = 1.0
+        stop_value_change_condition.time = 0.0
+
+        logging_specification.set_start_trigger_settings_to_value_change(start_value_change_condition)
+        logging_specification.set_stop_trigger_settings_to_value_change(stop_value_change_condition)
+
+        print("Press Enter to close the project...")
+        input()
+        project.close()
+
+    return 0
+
+
+if __name__ == "__main__":
+    argv = sys.argv
+    if len(argv) < 2:
+        print("Usage: %s <path of project to open>" % os.path.basename(__file__))
+        sys.exit()
+    project_path_arg = argv[1]
+    sys.exit(main(project_path_arg))

--- a/protobuf/ConfigurationBasedSoftware/FlexLogger/Automation/FlexLogger.Automation.Protocols/LoggingSpecificationDocument.proto
+++ b/protobuf/ConfigurationBasedSoftware/FlexLogger/Automation/FlexLogger.Automation.Protocols/LoggingSpecificationDocument.proto
@@ -2,8 +2,13 @@
 
 package national_instruments.flex_logger.automation.protocols;
 
+import "ConfigurationBasedSoftware/FlexLogger/Automation/FlexLogger.Automation.Protocols/StartTriggerCondition.proto";
+import "ConfigurationBasedSoftware/FlexLogger/Automation/FlexLogger.Automation.Protocols/StopTriggerCondition.proto";
+import "ConfigurationBasedSoftware/FlexLogger/Automation/FlexLogger.Automation.Protocols/ValueChangeType.proto";
 import "DiagramSdk/Automation/DiagramSdk.Automation.Protocols/Identifiers.proto";
+import "google/protobuf/duration.proto";
 import "google/protobuf/empty.proto";
+import "google/protobuf/timestamp.proto";
 
 // Service interface for a server side logging specification document.
 service LoggingSpecificationDocument {
@@ -33,6 +38,26 @@ service LoggingSpecificationDocument {
     rpc GetResolvedLogFileBasePath(GetResolvedLogFileBasePathRequest) returns (GetResolvedLogFileBasePathResponse) {}
     // RPC call to get the resolved log file name
     rpc GetResolvedLogFileName(GetResolvedLogFileNameRequest) returns (GetResolvedLogFileNameResponse) {}
+    // RPC call to get the start trigger settings
+    rpc GetStartTriggerSettings(GetStartTriggerSettingsRequest) returns (GetStartTriggerSettingsResponse) {}
+    // RPC call to get the stop trigger settings
+    rpc GetStopTriggerSettings(GetStopTriggerSettingsRequest) returns (GetStopTriggerSettingsResponse) {}
+    // RPC call to set the start trigger settings to Test Start
+    rpc SetTestStartTriggerSettings(SetTestStartTriggerSettingsRequest) returns (google.protobuf.Empty) {}
+    // RPC call to set the start trigger settings to Channel value change
+    rpc SetValueChangeStartTriggerSettings(SetValueChangeStartTriggerSettingsRequest) returns (google.protobuf.Empty) {}
+    // RPC call to set the start trigger settings to Absolute time
+    rpc SetTimeStartTriggerSettings(SetTimeStartTriggerSettingsRequest) returns (google.protobuf.Empty) {}
+    // RPC call to set the stop trigger settings to Test stop
+    rpc SetTestStopTriggerSettings(SetTestStopTriggerSettingsRequest) returns (google.protobuf.Empty) {}
+    // RPC call to set the stop trigger settings to Channel value change
+    rpc SetValueChangeStopTriggerSettings(SetValueChangeStopTriggerSettingsRequest) returns (google.protobuf.Empty) {}
+    // RPC call to set the stop trigger settings to Test time elapsed
+    rpc SetTimeStopTriggerSettings(SetTimeStopTriggerSettingsRequest) returns (google.protobuf.Empty) {}
+    // RPC call to get the retrigerring configuration
+    rpc IsRetriggeringEnabled(IsRetriggeringEnabledRequest) returns (IsRetriggeringEnabledResponse) {}
+    // RPC call to set the retrigerring configuration
+    rpc SetRetriggering(SetRetriggeringRequest) returns (google.protobuf.Empty) {}
 }
 
 // Request object for getting the log file base path
@@ -192,3 +217,114 @@ message GetResolvedLogFileNameResponse {
     string resolved_log_file_name = 1;
 }
 
+// Request object for getting the start trigger settings
+message GetStartTriggerSettingsRequest {
+    // The id for the logging specification document
+    national_instruments.diagram_sdk.automation.protocols.ElementIdentifier document_identifier = 1;
+}
+
+// Response object for a getting the start trigger settings
+message GetStartTriggerSettingsResponse {
+    // The start trigger condition
+    StartTriggerCondition start_trigger_condition = 1;
+    // The start trigger settings
+    string start_trigger_settings = 2;
+}
+
+// Request object for getting the stop trigger settings
+message GetStopTriggerSettingsRequest {
+    // The id for the logging specification document
+    national_instruments.diagram_sdk.automation.protocols.ElementIdentifier document_identifier = 1;
+}
+
+// Response object for getting the stop trigger settings
+message GetStopTriggerSettingsResponse {
+    // The stop trigger condition
+    StopTriggerCondition stop_trigger_condition = 1;
+    // The stop trigger settings
+    string stop_trigger_settings = 2;
+}
+
+// Request object for SetTestStartTriggerSettings
+message SetTestStartTriggerSettingsRequest {
+    // The id for the logging specification document
+    national_instruments.diagram_sdk.automation.protocols.ElementIdentifier document_identifier = 1;
+}
+
+// Request object for SetValueChangeStartTriggerSettings
+message SetValueChangeStartTriggerSettingsRequest {
+    // The id for the logging specification document
+    national_instruments.diagram_sdk.automation.protocols.ElementIdentifier document_identifier = 1;
+    // The channel name
+    string channel_name = 2;
+    // The value change condition
+    ValueChangeType value_change_type = 3;
+    // The threshold
+    double threshold = 4;
+    // The min value
+    double min_value = 5;
+    // The max value
+    double max_value = 6;
+    // The leading time to include in seconds
+    double leading_time = 7;
+}
+
+// Request object for SetTimeStartTriggerSettings
+message SetTimeStartTriggerSettingsRequest {
+    // The id for the logging specification document
+    national_instruments.diagram_sdk.automation.protocols.ElementIdentifier document_identifier = 1;
+    // The time to start the test
+    google.protobuf.Timestamp time = 2;
+}
+
+// Request object for SetTestStopTriggerSettings
+message SetTestStopTriggerSettingsRequest {
+    // The id for the logging specification document
+    national_instruments.diagram_sdk.automation.protocols.ElementIdentifier document_identifier = 1;
+}
+
+// Request object for SetValueChangeStopTriggerSettings
+message SetValueChangeStopTriggerSettingsRequest {
+    // The id for the logging specification document
+    national_instruments.diagram_sdk.automation.protocols.ElementIdentifier document_identifier = 1;
+    // The channel name
+    string channel_name = 2;
+    // The value change condition
+    ValueChangeType value_change_type = 3;
+    // The threshold
+    double threshold = 4;
+    // The min value
+    double min_value = 5;
+    // The max value
+    double max_value = 6;
+    // The leading time to include in seconds
+    double trailing_time = 7;
+}
+
+// Request object for SetTimeStopTriggerSettings
+message SetTimeStopTriggerSettingsRequest {
+    // The id for the logging specification document
+    national_instruments.diagram_sdk.automation.protocols.ElementIdentifier document_identifier = 1;
+    // The duration
+    google.protobuf.Duration duration = 2;
+}
+
+// Request object for IsRetriggeringEnabled
+message IsRetriggeringEnabledRequest {
+    // The id for the logging specification document
+    national_instruments.diagram_sdk.automation.protocols.ElementIdentifier document_identifier = 1;
+}
+
+// Response object for IsRetriggeringEnabled
+message IsRetriggeringEnabledResponse {
+    // The retriggering configuration
+    bool is_retriggering_enabled = 1;
+}
+
+// Request object for SetRetriggering
+message SetRetriggeringRequest {
+    // The id for the logging specification document
+    national_instruments.diagram_sdk.automation.protocols.ElementIdentifier document_identifier = 1;
+    // The triggering configuration
+    bool is_retriggering_enabled = 2;
+}

--- a/protobuf/ConfigurationBasedSoftware/FlexLogger/Automation/FlexLogger.Automation.Protocols/StartTriggerCondition.proto
+++ b/protobuf/ConfigurationBasedSoftware/FlexLogger/Automation/FlexLogger.Automation.Protocols/StartTriggerCondition.proto
@@ -1,0 +1,9 @@
+syntax = "proto3";
+
+package national_instruments.flex_logger.automation.protocols;
+
+enum StartTriggerCondition {
+  START_TRIGGER_CONDITION_TEST_START = 0;
+  START_TRIGGER_CONDITION_CHANNEL_VALUE_CHANGE  = 1;
+  START_TRIGGER_CONDITION_TIME = 2;
+}

--- a/protobuf/ConfigurationBasedSoftware/FlexLogger/Automation/FlexLogger.Automation.Protocols/StopTriggerCondition.proto
+++ b/protobuf/ConfigurationBasedSoftware/FlexLogger/Automation/FlexLogger.Automation.Protocols/StopTriggerCondition.proto
@@ -1,0 +1,9 @@
+syntax = "proto3";
+
+package national_instruments.flex_logger.automation.protocols;
+
+enum StopTriggerCondition {
+  STOP_TRIGGER_CONDITION_TEST_STOP = 0;
+  STOP_TRIGGER_CONDITION_CHANNEL_VALUE_CHANGE  = 1;
+  STOP_TRIGGER_CONDITION_TIME_ELAPSED = 2;
+}

--- a/protobuf/ConfigurationBasedSoftware/FlexLogger/Automation/FlexLogger.Automation.Protocols/ValueChangeType.proto
+++ b/protobuf/ConfigurationBasedSoftware/FlexLogger/Automation/FlexLogger.Automation.Protocols/ValueChangeType.proto
@@ -1,0 +1,13 @@
+syntax = "proto3";
+
+package national_instruments.flex_logger.automation.protocols;
+
+enum ValueChangeType {
+  TYPE_NONE = 0;
+  TYPE_RISE_ABOVE_VALUE = 1;
+  TYPE_RISE_ABOVE_VALUE_INCLUSIVE = 2;
+  TYPE_FALL_BELOW_VALUE = 3;
+  TYPE_FALL_BELOW_VALUE_INCLUSIVE = 4;
+  TYPE_ENTER_RANGE = 5;
+  TYPE_LEAVE_RANGE = 6;
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ grpcio
 importlib
 prettytable
 psutil
+python-dateutil
 # This package only works correctly on Windows,
 # but add this specifier to allow installing it on
 # Linux, which is helpful for pypi builds and readthedocs.

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ def _get_version(name: str) -> str:
     script_dir = os.path.dirname(os.path.realpath(__file__))
     script_dir = os.path.join(script_dir, name)
     if not os.path.exists(os.path.join(script_dir, "VERSION")):
-        version = "0.1.6"
+        version = "0.1.7"
     else:
         with open(os.path.join(script_dir, "VERSION"), "r") as version_file:
             version = version_file.read().rstrip()
@@ -99,6 +99,7 @@ setup(
         "pywin32; platform_system=='Windows'",
         "console-menu",
         "PrettyTable",
+        "python-dateutil",
     ],
     setup_requires=["grpcio", "grpcio-tools"],
     tests_require=["pytest", "mypy", "npTDMS", "pytest-timeout", "psutil"],

--- a/src/flexlogger/automation/__init__.py
+++ b/src/flexlogger/automation/__init__.py
@@ -18,3 +18,7 @@ from . import _event_names as EventNames
 from ._event_type import EventType
 from ._events import FlexLoggerEventHandler
 from ._severity_level import SeverityLevel
+from ._start_trigger_condition import StartTriggerCondition
+from ._stop_trigger_condition import StopTriggerCondition
+from ._value_change_condition import ValueChangeCondition
+from ._value_change_type import ValueChangeType

--- a/src/flexlogger/automation/_start_trigger_condition.py
+++ b/src/flexlogger/automation/_start_trigger_condition.py
@@ -1,0 +1,35 @@
+from enum import Enum
+from .proto.StartTriggerCondition_pb2 import StartTriggerCondition as StartTriggerCondition_pb2
+
+
+class StartTriggerCondition(Enum):
+    """An enumeration describing when to the logging starts."""
+
+    """Manually begin logging by clicking RUN."""
+    TEST_START = 0
+
+    """Begin logging when the value of the channel meets the specified value change condition."""
+    CHANNEL_VALUE_CHANGE = 1
+
+    """Begin logging at a designated date and time."""
+    ABSOLUTE_TIME = 2
+
+    def to_start_trigger_condition_pb2(self) -> StartTriggerCondition_pb2:
+        return START_TRIGGER_CONDITION_MAP.get(self.value)
+
+    @staticmethod
+    def from_start_trigger_condition_pb2(start_trigger_condition: StartTriggerCondition_pb2):
+        return START_TRIGGER_CONDITION_PB2_MAP.get(start_trigger_condition)
+
+
+START_TRIGGER_CONDITION_MAP = {
+    0: StartTriggerCondition_pb2.START_TRIGGER_CONDITION_TEST_START,
+    1: StartTriggerCondition_pb2.START_TRIGGER_CONDITION_CHANNEL_VALUE_CHANGE,
+    2: StartTriggerCondition_pb2.START_TRIGGER_CONDITION_TIME
+}
+
+START_TRIGGER_CONDITION_PB2_MAP = {
+    StartTriggerCondition_pb2.START_TRIGGER_CONDITION_TEST_START: StartTriggerCondition.TEST_START,
+    StartTriggerCondition_pb2.START_TRIGGER_CONDITION_CHANNEL_VALUE_CHANGE: StartTriggerCondition.CHANNEL_VALUE_CHANGE,
+    StartTriggerCondition_pb2.START_TRIGGER_CONDITION_TIME: StartTriggerCondition.ABSOLUTE_TIME
+}

--- a/src/flexlogger/automation/_stop_trigger_condition.py
+++ b/src/flexlogger/automation/_stop_trigger_condition.py
@@ -1,0 +1,35 @@
+from enum import Enum
+from .proto.StopTriggerCondition_pb2 import StopTriggerCondition as StopTriggerCondition_pb2
+
+
+class StopTriggerCondition(Enum):
+    """An enumeration describing when to the logging stops."""
+
+    """Manually stop logging by clicking the STOP button."""
+    TEST_STOP = 0
+
+    """Stop logging when the value of the acquisition on a designated channel meets the specified value change condition."""
+    CHANNEL_VALUE_CHANGE = 1
+
+    """Stop logging after a designated duration of time has elapsed."""
+    TEST_TIME_ELAPSED = 2
+
+    def to_stop_trigger_condition_pb2(self) -> StopTriggerCondition_pb2:
+        return STOP_TRIGGER_CONDITION_MAP.get(self.value)
+
+    @staticmethod
+    def from_stop_trigger_condition_pb2(stop_trigger_condition: StopTriggerCondition_pb2):
+        return STOP_TRIGGER_CONDITION_PB2_MAP.get(stop_trigger_condition)
+
+
+STOP_TRIGGER_CONDITION_MAP = {
+    0: StopTriggerCondition_pb2.STOP_TRIGGER_CONDITION_TEST_STOP,
+    1: StopTriggerCondition_pb2.STOP_TRIGGER_CONDITION_CHANNEL_VALUE_CHANGE,
+    2: StopTriggerCondition_pb2.STOP_TRIGGER_CONDITION_TIME_ELAPSED
+}
+
+STOP_TRIGGER_CONDITION_PB2_MAP = {
+    StopTriggerCondition_pb2.STOP_TRIGGER_CONDITION_TEST_STOP: StopTriggerCondition.TEST_STOP,
+    StopTriggerCondition_pb2.STOP_TRIGGER_CONDITION_CHANNEL_VALUE_CHANGE: StopTriggerCondition.CHANNEL_VALUE_CHANGE,
+    StopTriggerCondition_pb2.STOP_TRIGGER_CONDITION_TIME_ELAPSED: StopTriggerCondition.TEST_TIME_ELAPSED
+}

--- a/src/flexlogger/automation/_value_change_condition.py
+++ b/src/flexlogger/automation/_value_change_condition.py
@@ -1,0 +1,103 @@
+from ._value_change_type import ValueChangeType
+import json
+
+
+class ValueChangeCondition:
+    """Represents a value change condition.
+     Create a ValueChangeCondition object when you want to set the start or stop trigger to value change.
+    """
+
+    def __init__(self, value_change_condition='') -> None:
+        if len(value_change_condition) > 0:
+            json_condition = json.loads(value_change_condition)
+            self._channel_name = json_condition['ChannelName']
+            self._value_change_type = ValueChangeType.from_value_change_type_pb2(int(json_condition['ValueChangeType']))
+            self._threshold = float(json_condition['Threshold'])
+            self._min_value = float(json_condition['MinValue'])
+            self._max_value = float(json_condition['MaxValue'])
+            self._time = float(json_condition['Time'])
+        else:
+            self._channel_name = ''
+            self._value_change_type = ValueChangeType.NONE
+            self._threshold = 0
+            self._min_value = 0
+            self._max_value = 0
+            self._time = 0
+
+    def __eq__(self, other):
+        objects_equal = (self._channel_name == other.channel_name and
+                         self._value_change_type == other.value_change_type and
+                         self._threshold == other.threshold and
+                         self._min_value == other.min_value and
+                         self._max_value == other.max_value and
+                         self._time == other.time)
+        return objects_equal
+
+    def __repr__(self):
+        value_change_condition_string = 'ValueChangeCondition\r\n' \
+                                        'channel_name = {0}\r\n' \
+                                        'value_change_type = {1}\r\n' \
+                                        'threshold = {2}\r\n' \
+                                        'min_value = {3}\r\n' \
+                                        'max_value = {4}\r\n' \
+                                        'time = {5}'.format(self._channel_name,
+                                                            self._value_change_type,
+                                                            self._threshold,
+                                                            self._min_value,
+                                                            self._max_value,
+                                                            self._time)
+        return value_change_condition_string
+
+    @property
+    def channel_name(self) -> str:
+        """The channel name."""
+        return self._channel_name
+
+    @channel_name.setter
+    def channel_name(self, value: str):
+        self._channel_name = value
+
+    @property
+    def value_change_type(self) -> ValueChangeType:
+        """The value change type."""
+        return self._value_change_type
+
+    @value_change_type.setter
+    def value_change_type(self, value: ValueChangeType):
+        self._value_change_type = value
+
+    @property
+    def threshold(self) -> float:
+        """The threshold."""
+        return self._threshold
+
+    @threshold.setter
+    def threshold(self, value: float):
+        self._threshold = value
+
+    @property
+    def min_value(self) -> float:
+        """The range minimum."""
+        return self._min_value
+
+    @min_value.setter
+    def min_value(self, value: float):
+        self._min_value = value
+
+    @property
+    def max_value(self) -> float:
+        """The range maximum."""
+        return self._max_value
+
+    @max_value.setter
+    def max_value(self, value: float):
+        self._max_value = value
+
+    @property
+    def time(self) -> float:
+        """The leading or trailing time in seconds."""
+        return self._time
+
+    @time.setter
+    def time(self, value: float):
+        self._time = value

--- a/src/flexlogger/automation/_value_change_type.py
+++ b/src/flexlogger/automation/_value_change_type.py
@@ -1,0 +1,47 @@
+from enum import Enum
+from .proto.ValueChangeType_pb2 import ValueChangeType as ValueChangeType_pb2
+
+
+class ValueChangeType(Enum):
+    """An enumeration describing the possible types of value change events."""
+
+    """Start Trigger not configured."""
+    NONE = 0
+
+    """Start or stop a test when a channel value rises above a specified value."""
+    RISE_ABOVE_VALUE = 1
+
+    """Start or stop a test when a channel value falls below a specified value."""
+    FALL_BELOW_VALUE = 3
+
+    """Start or stop a test when a channel value enters a range."""
+    ENTER_RANGE = 5
+
+    """Start or stop a test when a channel value leaves a range."""
+    LEAVE_RANGE = 6
+
+    def to_value_change_type_pb2(self) -> ValueChangeType_pb2:
+        return VALUE_CHANGE_TYPE_MAP.get(self.value)
+
+    @staticmethod
+    def from_value_change_type_pb2(value_change_type: ValueChangeType_pb2):
+        return VALUE_CHANGE_TYPE_PB2_MAP.get(value_change_type)
+
+
+VALUE_CHANGE_TYPE_MAP = {
+    0: ValueChangeType_pb2.TYPE_NONE,
+    1: ValueChangeType_pb2.TYPE_RISE_ABOVE_VALUE,
+    2: ValueChangeType_pb2.TYPE_RISE_ABOVE_VALUE_INCLUSIVE,
+    3: ValueChangeType_pb2.TYPE_FALL_BELOW_VALUE,
+    4: ValueChangeType_pb2.TYPE_FALL_BELOW_VALUE_INCLUSIVE,
+    5: ValueChangeType_pb2.TYPE_ENTER_RANGE,
+    6: ValueChangeType_pb2.TYPE_LEAVE_RANGE
+}
+
+VALUE_CHANGE_TYPE_PB2_MAP = {
+    ValueChangeType_pb2.TYPE_NONE: ValueChangeType.NONE,
+    ValueChangeType_pb2.TYPE_RISE_ABOVE_VALUE: ValueChangeType.RISE_ABOVE_VALUE,
+    ValueChangeType_pb2.TYPE_FALL_BELOW_VALUE: ValueChangeType.FALL_BELOW_VALUE,
+    ValueChangeType_pb2.TYPE_ENTER_RANGE: ValueChangeType.ENTER_RANGE,
+    ValueChangeType_pb2.TYPE_LEAVE_RANGE: ValueChangeType.LEAVE_RANGE
+}

--- a/tests/assets/ProjectWithLoggingSpecification/Channel Specification.flxio
+++ b/tests/assets/ProjectWithLoggingSpecification/Channel Specification.flxio
@@ -1,10 +1,12 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<SourceFile Checksum="4D9E031E733A3E8C91849792190415369609DF38FFB30D46E60F10FF5D0C83311228ACE8A55AD9B77DE48882D1711EAD8C8E01790F08138DC951F0D0F1080205" Timestamp="1D665F58F66400B" xmlns="http://www.ni.com/PlatformFramework">
+<SourceFile Checksum="8AEB1AA2F7E72084A97C19B685C2BECAF7129D4B8FBF5EC683B5A983D4489D0C0A1B2A84FD7C4712C9DE1656C223EAD1F47F8C4791162CB59B429BEE9913BE84" Timestamp="1D9EA8207431C98" xmlns="http://www.ni.com/PlatformFramework">
 	<SourceModelFeatureSet>
-		<ParsableNamespace AssemblyFileVersion="8.3.0.2028" FeatureSetName="FlexLogger DAQmx" Name="http://www.ni.com/FlexLogger/DAQmx" OldestCompatibleVersion="8.3.0.5" Version="8.3.0.5" />
-		<ParsableNamespace AssemblyFileVersion="8.3.0.2028" FeatureSetName="Lumberjack Core" Name="http://www.ni.com/Lumberjack.Core" OldestCompatibleVersion="8.1.0.49152" Version="8.1.0.49152" />
-		<ParsableNamespace AssemblyFileVersion="8.3.0.2028" FeatureSetName="Editor" Name="http://www.ni.com/PlatformFramework" OldestCompatibleVersion="8.1.0.49152" Version="8.1.0.49152" />
-		<ApplicationVersionInfo Build="8.3.0.2028" Name="FlexLogger" Version="20.3.0.0" />
+		<ParsableNamespace AssemblyFileVersion="9.10.0.2344" FeatureSetName="FlexLogger DAQmx" Name="http://www.ni.com/FlexLogger/DAQmx" OldestCompatibleVersion="9.9.0.49152" Version="9.9.0.49152" />
+		<ParsableNamespace AssemblyFileVersion="9.10.0.2555" FeatureSetName="FlexLogger XNET" Name="http://www.ni.com/FlexLogger/XNET" OldestCompatibleVersion="9.3.0.49152" Version="9.3.0.49152" />
+		<ParsableNamespace AssemblyFileVersion="9.10.0.2555" FeatureSetName="Lumberjack Core" Name="http://www.ni.com/Lumberjack.Core" OldestCompatibleVersion="9.10.0.1" Version="9.10.0.1" />
+		<ParsableNamespace AssemblyFileVersion="9.10.0.2546" FeatureSetName="Calculated Channels" Name="http://www.ni.com/Lumberjack.Providers.CalculatedChannel" OldestCompatibleVersion="9.0.0.49152" Version="9.0.0.49152" />
+		<ParsableNamespace AssemblyFileVersion="9.10.0.2546" FeatureSetName="Editor" Name="http://www.ni.com/PlatformFramework" OldestCompatibleVersion="8.1.0.49152" Version="8.1.0.49152" />
+		<ApplicationVersionInfo Build="9.10.0.2344" Name="FlexLogger" Version="23.6.0.0" />
 	</SourceModelFeatureSet>
 	<ChannelSpecification xmlns="http://www.ni.com/Lumberjack.Core">
 		<ChannelConfigurationModel Id="982c173af0c64610a860339d38593bba">
@@ -18,8 +20,107 @@
 						<SampleTiming Id="a2c36c356af34115b9d6825ac7f4fc20" Level="[SampleRateLevel]LegacyCounter" Units="[Unit]Hertz" Value="[double]100" />
 						<SampleTiming Id="814122c312aa4893a2481f15bcb5bd74" Level="[SampleRateLevel]Digital" Units="[Unit]Hertz" Value="[double]10" />
 						<OnDemandTiming Id="930f7580a3a54932a0b7431eb8c0d42c" Level="[SampleRateLevel]OnDemand" />
+						<SampleTiming Id="b8a327accf245468f3a40413ebf50c7" Level="[SampleRateLevel]AnalogOutput" Units="[Unit]Hertz" Value="[double]10" />
 					</TopLevelTimingOwner>
 				</DAQmxProcessingElement>
+				<XnetPortModel CustomBaudrates="" CustomFdBaudrates="" Id="9a0e3949051d45778312e35e5f6ca7f5" PhysicalPort="[string]NI 9862/Port1" ProcessingElementName="[string]CAN2" TransceiverCapability="HighSpeed" xmlns="http://www.ni.com/FlexLogger/XNET">
+					<XnetProcessingElementParameter Id="de237e0c20144a268e6c4ad66804228b" ParameterName="[string]Settings JSON" Type="[Type]String" Value="[string]" />
+					<XnetCommunicationStatusOutputInfo CriticalAlarm="33429444b3814f69b886a58bcd4d3990" DataType="[Type]String" FullName="CAN2 Communication status" Id="969986e2db5040c08cc08fc2a1a1466b" LoggingDisabled="[bool]True" SampleRate="[double]100" Source="Output" Units="[string]" WarningAlarm="936802351e344aaa83e2f18958110981">
+						<AlarmModel Id="936802351e344aaa83e2f18958110981" Severity="[AlarmSeverity]Warning" TriggerModel="a38c67e5dd494786844d11d3cefd3bf9" xmlns="http://www.ni.com/Lumberjack.Core">
+							<ChannelMonitorTriggerModel Alias="[string]c7d4ce04-a8b5-4d0c-8b23-196ea05f175b" AliasToMonitor="[string]CAN2 Communication status" Id="a38c67e5dd494786844d11d3cefd3bf9">
+								<AboveValueTriggerModel Id="c9d3f08db394b9c99cca9126726d00d" />
+							</ChannelMonitorTriggerModel>
+						</AlarmModel>
+						<AlarmModel Id="33429444b3814f69b886a58bcd4d3990" Severity="[AlarmSeverity]Critical" TriggerModel="ec802cd73bd44e27aad4ae7724a42076" xmlns="http://www.ni.com/Lumberjack.Core">
+							<ChannelMonitorTriggerModel Alias="[string]4f192af7-52c9-4c33-8ebb-4aec8016f85b" AliasToMonitor="[string]CAN2 Communication status" Id="ec802cd73bd44e27aad4ae7724a42076">
+								<AboveValueTriggerModel Id="64676854e70b4513a5338cf3f0f775bd" />
+							</ChannelMonitorTriggerModel>
+						</AlarmModel>
+					</XnetCommunicationStatusOutputInfo>
+					<XnetRawFrameOutputInfo CriticalAlarm="33cef1fccf554a71833ee9e6a14523c6" DataType="[Type]Wfm(UInt8)" FullName="CAN2 Raw Logging" Id="7906228e6504a4a9e03f8ac0728b242" SampleRate="[double]100" Source="Raw" Units="[string]" WarningAlarm="89f8c3ef08df4af3bc766e4cfa736e37">
+						<AlarmModel Id="89f8c3ef08df4af3bc766e4cfa736e37" Severity="[AlarmSeverity]Warning" TriggerModel="19385343aef844e5922d54e63ab16bcc" xmlns="http://www.ni.com/Lumberjack.Core">
+							<ChannelMonitorTriggerModel Alias="[string]58622ddb-1261-460f-8785-05a171e406a4" AliasToMonitor="[string]CAN2 Raw Logging" Id="19385343aef844e5922d54e63ab16bcc">
+								<AboveValueTriggerModel Id="dabc371b5da348aaa35ff32269dd31b3" />
+							</ChannelMonitorTriggerModel>
+						</AlarmModel>
+						<AlarmModel Id="33cef1fccf554a71833ee9e6a14523c6" Severity="[AlarmSeverity]Critical" TriggerModel="a7297e0dd25e4b6e9335c4c284e9ea2b" xmlns="http://www.ni.com/Lumberjack.Core">
+							<ChannelMonitorTriggerModel Alias="[string]969edd1b-6679-42be-b50d-705303dbb7f9" AliasToMonitor="[string]CAN2 Raw Logging" Id="a7297e0dd25e4b6e9335c4c284e9ea2b">
+								<AboveValueTriggerModel Id="d07914e33761410d95653006989f03e9" />
+							</ChannelMonitorTriggerModel>
+						</AlarmModel>
+					</XnetRawFrameOutputInfo>
+					<XnetRawFrameInputInfo FullName="Raw Frame Input" Id="dfc27bb4b7b44f4a31acc7dcb2667b8" Source="Input" />
+					<XnetBusStatisticsOutputInfo CriticalAlarm="ff75765c4b3d44b78f8d549668061b06" DataType="[Type]String" FullName="CAN2 Bus Statistics" Id="5186e3b9aeb7450ea82a71304f31c0ea" LoggingDisabled="[bool]True" SampleRate="[double]100" Source="Output" Units="[string]" WarningAlarm="5d471e7f1e6499d9e0030089511ac4f">
+						<AlarmModel Id="5d471e7f1e6499d9e0030089511ac4f" Severity="[AlarmSeverity]Warning" TriggerModel="e9a1a1da228442619d686f4026c3df66" xmlns="http://www.ni.com/Lumberjack.Core">
+							<ChannelMonitorTriggerModel Alias="[string]764cf632-8c0a-41a9-b2a9-8e94a9909def" AliasToMonitor="[string]CAN2 Bus Statistics" Id="e9a1a1da228442619d686f4026c3df66">
+								<AboveValueTriggerModel Id="f89b2bdad7ad48e9afe1a8aae3b0ff31" />
+							</ChannelMonitorTriggerModel>
+						</AlarmModel>
+						<AlarmModel Id="ff75765c4b3d44b78f8d549668061b06" Severity="[AlarmSeverity]Critical" TriggerModel="9367fd495b894390b948d41b231b7064" xmlns="http://www.ni.com/Lumberjack.Core">
+							<ChannelMonitorTriggerModel Alias="[string]7fcfe7c3-5c5b-40c6-a980-76e7e2556837" AliasToMonitor="[string]CAN2 Bus Statistics" Id="9367fd495b894390b948d41b231b7064">
+								<AboveValueTriggerModel Id="e81785aefdd4c9ca798f43a4d9d492a" />
+							</ChannelMonitorTriggerModel>
+						</AlarmModel>
+					</XnetBusStatisticsOutputInfo>
+				</XnetPortModel>
+				<XnetPortModel CustomBaudrates="" CustomFdBaudrates="" Id="922622767c0e41a5abac5dc7bfe4659a" PhysicalPort="[string]NI 9862/Port1" ProcessingElementName="[string]CAN1" TransceiverCapability="HighSpeed" xmlns="http://www.ni.com/FlexLogger/XNET">
+					<XnetProcessingElementParameter Id="844fbd75a6134f57a0cd575893648a96" ParameterName="[string]Settings JSON" Type="[Type]String" Value="[string]" />
+					<XnetCommunicationStatusOutputInfo CriticalAlarm="bb0aff2fa4e146909297dbaace1c974a" DataType="[Type]String" FullName="CAN1 Communication status" Id="8c1bc5be5ee349a9890c376d8c8e68ed" LoggingDisabled="[bool]True" SampleRate="[double]100" Source="Output" Units="[string]" WarningAlarm="a8ed13e0d2a44cfb8c35e10f5813360a">
+						<AlarmModel Id="a8ed13e0d2a44cfb8c35e10f5813360a" Severity="[AlarmSeverity]Warning" TriggerModel="a6b4f09438824ef1a4c30613256e9774" xmlns="http://www.ni.com/Lumberjack.Core">
+							<ChannelMonitorTriggerModel Alias="[string]8e574fb1-b70f-4bf6-9212-d9c260c9c3cf" AliasToMonitor="[string]CAN1 Communication status" Id="a6b4f09438824ef1a4c30613256e9774">
+								<AboveValueTriggerModel Id="25eee30ac56a4ae68a7280553fe76ebf" />
+							</ChannelMonitorTriggerModel>
+						</AlarmModel>
+						<AlarmModel Id="bb0aff2fa4e146909297dbaace1c974a" Severity="[AlarmSeverity]Critical" TriggerModel="dddc8f90b5564bae89cf02be5fc233e2" xmlns="http://www.ni.com/Lumberjack.Core">
+							<ChannelMonitorTriggerModel Alias="[string]3ecf6ed0-e054-40e8-96eb-4bfeee46fed6" AliasToMonitor="[string]CAN1 Communication status" Id="dddc8f90b5564bae89cf02be5fc233e2">
+								<AboveValueTriggerModel Id="306d3f7c76664948b7815571c0d78b03" />
+							</ChannelMonitorTriggerModel>
+						</AlarmModel>
+					</XnetCommunicationStatusOutputInfo>
+					<XnetRawFrameOutputInfo CriticalAlarm="eedcb03dec4a4b8b83ec932e10c7e4a3" DataType="[Type]Wfm(UInt8)" FullName="CAN1 Raw Logging" Id="cf52f8d3a1864222b14416cd722760a6" SampleRate="[double]100" Source="Raw" Units="[string]" WarningAlarm="e12948c2ddc46a6bcb9a204a4c9cec4">
+						<AlarmModel Id="e12948c2ddc46a6bcb9a204a4c9cec4" Severity="[AlarmSeverity]Warning" TriggerModel="ef52d23fc986487ea2dbd8336e266105" xmlns="http://www.ni.com/Lumberjack.Core">
+							<ChannelMonitorTriggerModel Alias="[string]fc88c48b-580a-4b24-ac11-3565679ffabd" AliasToMonitor="[string]CAN1 Raw Logging" Id="ef52d23fc986487ea2dbd8336e266105">
+								<AboveValueTriggerModel Id="587c199336754808ade8ce75f3083fcf" />
+							</ChannelMonitorTriggerModel>
+						</AlarmModel>
+						<AlarmModel Id="eedcb03dec4a4b8b83ec932e10c7e4a3" Severity="[AlarmSeverity]Critical" TriggerModel="dce5bb9c418b4315b6fe4cf0ac64ae2d" xmlns="http://www.ni.com/Lumberjack.Core">
+							<ChannelMonitorTriggerModel Alias="[string]610e36ad-fb74-4d8e-8ec3-18cb778c2edb" AliasToMonitor="[string]CAN1 Raw Logging" Id="dce5bb9c418b4315b6fe4cf0ac64ae2d">
+								<AboveValueTriggerModel Id="738cd3a9e6ac4292860c8ae8d6420fa4" />
+							</ChannelMonitorTriggerModel>
+						</AlarmModel>
+					</XnetRawFrameOutputInfo>
+					<XnetRawFrameInputInfo FullName="Raw Frame Input_1" Id="8902e1d1e42046af866859d9b0db3b64" Source="Input" />
+					<XnetBusStatisticsOutputInfo CriticalAlarm="d5744887533c40a38ab23fe920d9a285" DataType="[Type]String" FullName="CAN1 Bus Statistics" Id="cc10dc720b814b35860ef75a6880763c" LoggingDisabled="[bool]True" SampleRate="[double]100" Source="Output" Units="[string]" WarningAlarm="8e5a830c3294400db5e2d189aa7cf7f3">
+						<AlarmModel Id="8e5a830c3294400db5e2d189aa7cf7f3" Severity="[AlarmSeverity]Warning" TriggerModel="fe70882a25ea4a62b12adc112bb2991f" xmlns="http://www.ni.com/Lumberjack.Core">
+							<ChannelMonitorTriggerModel Alias="[string]4990c2e4-bdd4-48d2-999b-a18c7230915b" AliasToMonitor="[string]CAN1 Bus Statistics" Id="fe70882a25ea4a62b12adc112bb2991f">
+								<AboveValueTriggerModel Id="638c9023c8c347e89f5c0624aa11bd60" />
+							</ChannelMonitorTriggerModel>
+						</AlarmModel>
+						<AlarmModel Id="d5744887533c40a38ab23fe920d9a285" Severity="[AlarmSeverity]Critical" TriggerModel="7bb53caa0e8449a0863529c41403687b" xmlns="http://www.ni.com/Lumberjack.Core">
+							<ChannelMonitorTriggerModel Alias="[string]5faaf52c-e70b-4263-88cc-3b110c217018" AliasToMonitor="[string]CAN1 Bus Statistics" Id="7bb53caa0e8449a0863529c41403687b">
+								<AboveValueTriggerModel Id="cce9d4f1749b44c5ba757a0aadded4e4" />
+							</ChannelMonitorTriggerModel>
+						</AlarmModel>
+					</XnetBusStatisticsOutputInfo>
+				</XnetPortModel>
+				<VariableProvider Id="aabc3acc0aea40138f23718b1c4b03ef" ModelTypeId="[string]EAE65B83-4518-45A9-AA71-7A049C2B2563" xmlns="http://www.ni.com/Lumberjack.Providers.CalculatedChannel">
+					<VariableConsumer AssociatedProducer="[string]Variable.producer" FullName="Variable" Id="d9673fca91aa4ed890e9898d40dc55f3" MappingAlias="[string]e97b80e5-bc3b-40d0-a59d-8160e7f7fc85">
+						<SupportedDataType xmlns="http://www.ni.com/Lumberjack.Core" />
+					</VariableConsumer>
+					<VariableProducer CriticalAlarm="58e01ebb3f0d4e06ad613f697fec83a2" DataType="[Type]Double" FullName="Variable.producer" Id="23f2bed9c7d64395b8c91d6507a96da5" SampleRate="[double]100" Units="[string]" WarningAlarm="a132890f99294009963c68b86f385063">
+						<AlarmModel Id="a132890f99294009963c68b86f385063" Severity="[AlarmSeverity]Warning" TriggerModel="bc92babcfbf046cd9bffd29c1ab8baa4" xmlns="http://www.ni.com/Lumberjack.Core">
+							<ChannelMonitorTriggerModel Alias="[string]81011ad1-f45c-40ea-8544-0a78334ab999" AliasToMonitor="[string]Variable.producer" Id="bc92babcfbf046cd9bffd29c1ab8baa4">
+								<AboveValueTriggerModel Id="98f016ac8b374e8985dc7620b2eb4900" />
+							</ChannelMonitorTriggerModel>
+						</AlarmModel>
+						<AlarmModel Id="58e01ebb3f0d4e06ad613f697fec83a2" Severity="[AlarmSeverity]Critical" TriggerModel="d19c4bfc523b4fb6a3eab93c45cac9ba" xmlns="http://www.ni.com/Lumberjack.Core">
+							<ChannelMonitorTriggerModel Alias="[string]28808622-03e0-4f60-8229-eac7978969a6" AliasToMonitor="[string]Variable.producer" Id="d19c4bfc523b4fb6a3eab93c45cac9ba">
+								<AboveValueTriggerModel Id="25781e0c2e35426b9bc0e4abb9bb0c42" />
+							</ChannelMonitorTriggerModel>
+						</AlarmModel>
+						<Keyword Id="25c0872c07a7403e84296255f3266372" Name="NotPublicToSystemLink" xmlns="http://www.ni.com/Lumberjack.Core" />
+					</VariableProducer>
+				</VariableProvider>
 			</ProcessingElementModelOwner>
 		</ChannelConfigurationModel>
 		<ChassisModelOwner Id="462b641e98e04963bf760b558012bc65" />


### PR DESCRIPTION
- [X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/flexlogger-python/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Add functions to get and set the trigger settings in the logging specification document and support of a timeout when opening a project.
Creation of the following new Python client methods to get and set the trigger settings:
- get_start_trigger_settings
- get_stop_trigger_settings
- set_test_start_trigger_settings
- set_value_change_start_trigger_settings
- set_time_start_trigger_settings
- set_test_stop_trigger_settings
- set_value_change_stop_trigger_settings
- set_time_stop_trigger_settings
- is_retriggering_enabled
- set_retriggering

Add optional timeout parameter to the open_project function and update example.

### Why should this Pull Request be merged?

Adds new functionality to the FlexLogger automation API.

### What testing has been done?

Manual tests and added automated tests to verify the new functionality.

- [X] I have run the automated tests (required if there are code changes)