### PR TITLE
Fix get_registered_events type hint for Python 3.9 and below.

### DIFF
--- a/src/flexlogger/automation/_events.py
+++ b/src/flexlogger/automation/_events.py
@@ -13,7 +13,7 @@ from .proto.EventType_pb2 import EventType as EventType_pb2
 from concurrent.futures import ThreadPoolExecutor
 from google.protobuf.timestamp_pb2 import Timestamp
 from grpc import Channel, RpcError
-from typing import Callable, Iterator
+from typing import Callable, Iterator, List
 
 
 class FlexLoggerEventHandler:
@@ -41,7 +41,7 @@ class FlexLoggerEventHandler:
     def __exit__(self, *args):
         self.unregister_from_events()
 
-    def get_registered_events(self) -> list[EventType]:
+    def get_registered_events(self) -> List[EventType]:
         """Gets the list of registered event types.
 
         Returns


### PR DESCRIPTION
- [X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/flexlogger-python/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?
Fix the return type hint of the `get_registered_events` function to work in Python 3.9 and below.

### Why should this Pull Request be merged?
Fix a compatibility issue.

### What testing has been done?
Perform manual tests and ran automated tests.

- [X] I have run the automated tests (required if there are code changes)