### PR TITLE
Add get_version function to retrieve the version of FlexLogger the API connects to.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -15,7 +15,7 @@ Requirements
 ============
 **niflexlogger-automation** has the following requirements:
 
-* FlexLogger 2023 Q4+
+* FlexLogger 2024 Q1+
 * CPython 3.6 - 3.10. If you do not have Python installed on your computer, go to python.org/downloads to download and install it.
 
 .. _installation_section:

--- a/examples/Basic/launch_application.py
+++ b/examples/Basic/launch_application.py
@@ -10,6 +10,8 @@ def main(project_path):
     # goes out of scope, the application will be closed.  To prevent this,
     # call app.disconnect() before the scope ends.
     with Application.launch() as app:
+        versions = app.get_version()
+        print("FlexLogger version: " + versions[1])
         project = app.open_project(path=project_path, timeout=180)
         print("Press Enter to close project...")
         input()

--- a/protobuf/ConfigurationBasedSoftware/FlexLogger/Automation/FlexLogger.Automation.Protocols/FlexLoggerApplication.proto
+++ b/protobuf/ConfigurationBasedSoftware/FlexLogger/Automation/FlexLogger.Automation.Protocols/FlexLoggerApplication.proto
@@ -3,6 +3,7 @@
 package national_instruments.flex_logger.automation.protocols;
 
 import "DiagramSdk/Automation/DiagramSdk.Automation.Protocols/Identifiers.proto";
+import "google/protobuf/empty.proto";
 
 // Service interface for the server application.
 service FlexLoggerApplication {
@@ -10,6 +11,8 @@ service FlexLoggerApplication {
   rpc OpenProject(OpenProjectRequest) returns (OpenProjectResponse) {}
   // RPC call to get the currently active (open) project from the server.
   rpc GetActiveProject(GetActiveProjectRequest) returns (GetActiveProjectResponse) {}
+  // RPC call to get the FlexLogger version from the server.
+  rpc GetVersion(google.protobuf.Empty) returns (GetVersionResponse) {}
 }
 
 // Information necessary to open an existing Project.
@@ -35,4 +38,12 @@ message GetActiveProjectResponse {
     bool active_project_available = 1;
     // The id of the active project. Should not be used if active_project_available is false.
     national_instruments.diagram_sdk.automation.protocols.ProjectIdentifier project = 2;
+}
+
+// Response object for the get version request.
+message GetVersionResponse {
+    // The numeric internal version (24.0.0.0)
+    string version = 1;
+    // The string version contaning the year and quarter (2024 Q1)
+    string version_string = 2;
 }

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ def _get_version(name: str) -> str:
     script_dir = os.path.dirname(os.path.realpath(__file__))
     script_dir = os.path.join(script_dir, name)
     if not os.path.exists(os.path.join(script_dir, "VERSION")):
-        version = "0.1.8"
+        version = "0.1.9"
     else:
         with open(os.path.join(script_dir, "VERSION"), "r") as version_file:
             version = version_file.read().rstrip()

--- a/src/flexlogger/automation/_project.py
+++ b/src/flexlogger/automation/_project.py
@@ -146,6 +146,8 @@ class Project:
 
         Raises:
             FlexLoggerError: if saving the project fails due to a communication error.
+            If there is no communication error with the FlexLogger application, this function will not raise an
+            exception, but instead return a boolean indicating if the project was properly saved.
         """
         stub = Project_pb2_grpc.ProjectStub(self._channel)
         try:

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -1,0 +1,14 @@
+from flexlogger.automation import Application
+import pytest  # type: ignore
+import re
+
+
+class TestApplication:
+    @pytest.mark.integration  # type: ignore
+    def test__launch_flexLogger__get_versions__versions_match_pattern(self, app: Application) -> None:
+        version, version_string = app.get_version()
+
+        version_pattern = re.compile(r"2\d.\d.\d.\d")
+        assert version_pattern.match(version)
+        version_string_pattern = re.compile(r"20\d\d Q\d")
+        assert version_string_pattern.match(version_string)


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/flexlogger-python/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?
This changet implements a get_version function that returns the version of FlexLogger the API connects to.
It is compatible with FlexLogger 2024Q1 that is the latest version available for download.

### Why should this Pull Request be merged?
Add new functionality.

### What testing has been done?
- Added a new automated test exercising the new functionality.

- [x] I have run the automated tests (required if there are code changes)