### PR TITLE
v0.1.10: Get and remove entries from the data files pane

### DIFF
--- a/examples/Basic/run_test_session_and_show_log_file.py
+++ b/examples/Basic/run_test_session_and_show_log_file.py
@@ -1,0 +1,32 @@
+import os
+import sys
+
+from flexlogger.automation import Application, LogFileType
+
+
+def main(project_path):
+    """Launch FlexLogger, open a project, run a test session, and show log file."""
+    with Application.launch() as app:
+        project = app.open_project(path=project_path)
+        logging_specification = project.open_logging_specification_document()
+        logging_specification.remove_log_files(delete_files=True)
+        test_session = project.test_session
+        test_session.start()
+        print("Test started. Press Enter to stop the test and close the project...")
+        input()
+        test_session.stop()
+        log_files = logging_specification.get_log_files(LogFileType.TDMS)
+        project.close()
+        print("The following TDMS log files were created during the test session:")
+        for log_file in log_files:
+            print(log_file)
+    return 0
+
+
+if __name__ == "__main__":
+    argv = sys.argv
+    if len(argv) < 2:
+        print("Usage: %s <path of project to open>" % os.path.basename(__file__))
+        sys.exit()
+    project_path_arg = argv[1]
+    sys.exit(main(project_path_arg))

--- a/protobuf/ConfigurationBasedSoftware/FlexLogger/Automation/FlexLogger.Automation.Protocols/LoggingSpecificationDocument.proto
+++ b/protobuf/ConfigurationBasedSoftware/FlexLogger/Automation/FlexLogger.Automation.Protocols/LoggingSpecificationDocument.proto
@@ -24,6 +24,10 @@ service LoggingSpecificationDocument {
     rpc GetLogFileDescription(GetLogFileDescriptionRequest) returns (GetLogFileDescriptionResponse) {}
     // RPC call to set the description
     rpc SetLogFileDescription(SetLogFileDescriptionRequest) returns (google.protobuf.Empty) {}
+    // RPC call to get items from the data files pane
+    rpc GetLogFiles(GetLogFilesRequest) returns (GetLogFilesResponse) {}
+    // RPC call to clear the data files pane
+    rpc RemoveLogFiles(RemoveLogFilesRequest) returns (google.protobuf.Empty) {}
     // RPC call to get all test properties
     rpc GetTestProperties(GetTestPropertiesRequest) returns (GetTestPropertiesResponse) {}
     // RPC call to set all test properties
@@ -126,6 +130,38 @@ message SetLogFileDescriptionRequest {
     national_instruments.diagram_sdk.automation.protocols.ElementIdentifier document_identifier = 1;
     // The log file description
     string log_file_description = 2;
+}
+
+// Log file types
+enum LogFileType {
+    // TDMS files
+    TDMS = 0;
+    // CSV files
+    CSV = 1;
+    // TDMS backup files
+    TDMS_BACKUP = 2;
+}
+
+// Request object for GetLogFiles
+message GetLogFilesRequest {
+    // The id for the logging specification document
+    national_instruments.diagram_sdk.automation.protocols.ElementIdentifier document_identifier = 1;
+    // The type of log files to get
+    LogFileType log_file_type = 2;
+}
+
+// Response object for GetLogFiles
+message GetLogFilesResponse {
+    // The full paths on disk of the log files, sorted chronologically by file creation time
+    repeated string log_files = 1;
+}
+
+// Request object for RemoveLogFiles
+message RemoveLogFilesRequest {
+    // The id for the logging specification document
+    national_instruments.diagram_sdk.automation.protocols.ElementIdentifier document_identifier = 1;
+    // Delete files on disk?
+    bool delete_files = 2;
 }
 
 // Message that defines an individual test property

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ def _get_version(name: str) -> str:
     script_dir = os.path.dirname(os.path.realpath(__file__))
     script_dir = os.path.join(script_dir, name)
     if not os.path.exists(os.path.join(script_dir, "VERSION")):
-        version = "0.1.9"
+        version = "0.1.10"
     else:
         with open(os.path.join(script_dir, "VERSION"), "r") as version_file:
             version = version_file.read().rstrip()

--- a/src/flexlogger/automation/__init__.py
+++ b/src/flexlogger/automation/__init__.py
@@ -5,6 +5,7 @@ from ._test_session import TestSession
 from ._test_session_state import TestSessionState
 from ._channel_specification_document import ChannelSpecificationDocument
 from ._logging_specification_document import LoggingSpecificationDocument
+from ._log_file_type import LogFileType
 from ._screen_document import ScreenDocument
 from ._test_specification_document import TestSpecificationDocument
 from ._flexlogger_error import FlexLoggerError

--- a/src/flexlogger/automation/_flexlogger_error.py
+++ b/src/flexlogger/automation/_flexlogger_error.py
@@ -19,18 +19,33 @@ class FlexLoggerError(Exception):
     @property
     def message(self) -> str:
         """The error message."""
-        message = self._message
-        if isinstance(self.__cause__, RpcError):
-            cause = cast(RpcError, self.__cause__)
-            search_result = re.search(r"\(([^)]+)", cause.details())
-            inner_details = search_result.group(1)  # type: ignore
-            if len(inner_details) >= 0:
-                message += ". Additional error details: " + inner_details
-
-        return message
+        inner_details = self._get_inner_details()
+        if len(inner_details) == 0:
+            return self._message
+        
+        inner_details = re.sub(r"\[([0-9+-]+)\] ", "", inner_details)
+        return self._message + ". Additional error details: " + inner_details
+        
+    @property
+    def error_code(self) -> int:
+        """The error code."""
+        inner_details = self._get_inner_details()
+        if len(inner_details) == 0:
+            return 0
+        
+        error_code_result = re.search(r"\[([0-9+-]+)\] ", inner_details)
+        return int(error_code_result.group(1)) if error_code_result else 0
 
     def __repr__(self) -> str:
         return f"FlexLoggerError({repr(self.message)})"
 
     def __str__(self) -> str:
         return self.message
+
+    def _get_inner_details(self) -> str:
+        if not isinstance(self.__cause__, RpcError):
+            return ""
+        
+        cause = cast(RpcError, self.__cause__)
+        search_result = re.search(r"\(([^)]+)", cause.details())
+        return search_result.group(1)  # type: ignore

--- a/src/flexlogger/automation/_log_file_type.py
+++ b/src/flexlogger/automation/_log_file_type.py
@@ -1,0 +1,13 @@
+from enum import Enum
+
+class LogFileType(Enum):
+    """An enumeration describing the different log file types."""
+
+    TDMS = 0
+    """TDMS files"""
+
+    TDMS_BACKUP_FILES = 1
+    """TDMS backup files"""
+
+    CSV = 2
+    """CSV files"""


### PR DESCRIPTION
- [X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/flexlogger-python/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Add two methods to the automation API to:
- remove all entries in the data files pane (and optionally delete them from disk)
- get all entries in the data files pane: their paths on disk, their file creation times, and if they are backup files.

- Remove error code from error message.
- Extract error code from error message and provide value through new property on the exception.

### Why should this Pull Request be merged?

Customers have requested an automation method to clear the entries in the data files pane.
We also want to provide a method to obtain the entries in the data files pane.

### What testing has been done?

Automated tests and manual testing.

- [X] I have run the automated tests (required if there are code changes)