### PR TITLE
Add support for Python 3.11, 3.12, and 3.13 and update version

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -16,7 +16,7 @@ Requirements
 **niflexlogger-automation** has the following requirements:
 
 * FlexLogger 2024 Q1+
-* CPython 3.6 - 3.10. If you do not have Python installed on your computer, go to python.org/downloads to download and install it.
+* CPython 3.6 - 3.13. If you do not have Python installed on your computer, go to python.org/downloads to download and install it.
 
 .. _installation_section:
 

--- a/examples/README.rst
+++ b/examples/README.rst
@@ -16,7 +16,7 @@ The Python Examples folder includes the following types of examples:
 Requirements
 ============
 * FlexLogger 2022 Q2 or later
-* Python 3.6-3.10
+* Python 3.6-3.13
 * pymodbus 2.5.3 (Only for the Thermal Chamber with Communication Protocol example)
 * numpy 1.0 (Only for the Thermal Chamber with Communication Protocol example)
 

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ def _get_version(name: str) -> str:
     script_dir = os.path.dirname(os.path.realpath(__file__))
     script_dir = os.path.join(script_dir, name)
     if not os.path.exists(os.path.join(script_dir, "VERSION")):
-        version = "0.2.2"
+        version = "0.2.3"
     else:
         with open(os.path.join(script_dir, "VERSION"), "r") as version_file:
             version = version_file.read().rstrip()
@@ -115,6 +115,9 @@ setup(
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
         "Programming Language :: Python :: Implementation :: CPython",
         "Topic :: Scientific/Engineering",
         "Topic :: System :: Hardware",

--- a/tox.ini
+++ b/tox.ini
@@ -4,17 +4,17 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py310,py39,py38,py37,py36
+envlist = py313,py312,py311,py310,py39,py38,py37,py36
 requires =
     setuptools >= 40.1.0
 
 [testenv]
 deps =
-    py310: black
-    py310: docutils
-    py310: flake8
-    py310: flake8-docstrings
-    py310: flake8-import-order
+    py313: black
+    py313: docutils
+    py313: flake8
+    py313: flake8-docstrings
+    py313: flake8-import-order
     mypy
     pytest
     npTDMS
@@ -22,13 +22,13 @@ deps =
     psutil
 changedir = src
 commands =
-    py310: black --target-version py36 --exclude "flexlogger\/automation\/proto\/" --check flexlogger ../examples ../tests
-    py310: flake8 flexlogger ../examples/Basic ../examples/Interactive ../tests
-    py310: mypy --config-file ../mypy.ini -p flexlogger.automation
+    py313: black --target-version py36 --exclude "flexlogger\/automation\/proto\/" --check flexlogger ../examples ../tests
+    py313: flake8 flexlogger ../examples/Basic ../examples/Interactive ../tests
+    py313: mypy --config-file ../mypy.ini -p flexlogger.automation
     # We don't annotate types in our examples (to make them easier to read),
     # but do check that we're using types correctly
-    py310: mypy --config-file ../mypy.ini --allow-untyped-defs --allow-incomplete-defs ../examples/Basic ../examples/Interactive
-    py310: mypy --config-file ../mypy.ini ../tests
+    py313: mypy --config-file ../mypy.ini --allow-untyped-defs --allow-incomplete-defs ../examples/Basic ../examples/Interactive
+    py313: mypy --config-file ../mypy.ini ../tests
     pytest --doctest-modules flexlogger
     pytest ../tests --strict-markers {posargs:-m "(not slow)"}
 # WINDIR environment variable needs to be set or FlexLogger
@@ -44,6 +44,9 @@ python =
    3.8: py38
    3.9: py39
    3.10: py310
+   3.11: py311
+   3.12: py312
+   3.13: py313
 
 # Note that pytest args can be passed on the commandline after "--", e.g.
 #    tox -- -m integration


### PR DESCRIPTION
- [X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/flexlogger-python/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

- Add support for Python 3.11, 3.12, and 3.13
- Update API version to 0.2.3

### Why should this Pull Request be merged?

These changes add support for newer Python versions.

### What testing has been done?

I ran the automated tests against all three Python versions being added.

- [X] I have run the automated tests (required if there are code changes)