### PR TITLE
Enable PyPi trusted publishing

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -4,7 +4,6 @@ on:
   release:
     types: [published]
 
-# Default all jobs to minimal access.
 permissions:
   contents: read
 
@@ -14,8 +13,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      # For maximum supply-chain protection, replace version tags with
-      # reviewed full commit SHAs.
+
       - name: Check out release source
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
@@ -42,8 +40,14 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
 
+    environment:
+      name: pypi
+
+    permissions:
+      id-token: write
+
     steps:
-      # This privileged job does not check out or execute repository code.
+      
       - name: Download distributions
         uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5
         with:
@@ -52,6 +56,3 @@ jobs:
 
       - name: Publish distributions to PyPI
         uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # release/v1
-        with:
-          user: __token__
-          password: ${{ secrets.pypi_password }}


### PR DESCRIPTION
This pull request updates the `publish-to-pypi.yml` GitHub Actions workflow to improve security and align with best practices for publishing Python packages to PyPI. The main changes involve updating permissions, configuring the publishing environment, and switching to OpenID Connect (OIDC) authentication for PyPI publishing.

**Workflow security and publishing improvements:**

* Added an explicit `environment` block with `pypi` as the target environment for the publish job, enhancing deployment controls.
* Updated job permissions to grant `id-token: write` for the publish job, enabling secure authentication with PyPI using OIDC instead of static credentials.
* Removed the use of static `user` and `password` secrets for PyPI publishing, relying instead on OIDC authentication for increased security.

**Other workflow adjustments:**

* Removed outdated comments and clarified the purpose of steps in the workflow, simplifying the configuration.
* Cleaned up permissions declaration by removing a redundant comment, keeping only the necessary `contents: read` permission for the workflow.